### PR TITLE
Align skills with Agent Skills spec: add compatibility, fix paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/worktrees

--- a/ctf-crypto/SKILL.md
+++ b/ctf-crypto/SKILL.md
@@ -2,6 +2,7 @@
 name: ctf-crypto
 description: Cryptography attack techniques for CTF challenges. Use when attacking encryption, hashing, signatures, ZKP, PRNG, or mathematical crypto problems involving RSA, AES, ECC, lattices, number theory, Coppersmith, Pollard, Wiener, padding oracle, or stream/block cipher weaknesses.
 license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
 metadata:
   user-invocable: "false"

--- a/ctf-forensics/SKILL.md
+++ b/ctf-forensics/SKILL.md
@@ -2,6 +2,7 @@
 name: ctf-forensics
 description: Digital forensics and blockchain analysis for CTF challenges. Use when analyzing disk images, memory dumps, event logs, network captures, cryptocurrency transactions, steganography, PDF analysis, Windows registry, Volatility, PCAP, Docker images, coredumps, or recovering deleted files and credentials.
 license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
 metadata:
   user-invocable: "false"

--- a/ctf-malware/SKILL.md
+++ b/ctf-malware/SKILL.md
@@ -2,6 +2,7 @@
 name: ctf-malware
 description: Malware analysis and network traffic techniques for CTF challenges. Use when analyzing obfuscated scripts, malicious packages, custom crypto protocols, C2 traffic, PE/.NET binaries, RC4/AES encrypted communications, or extracting malware configurations and indicators of compromise.
 license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
 metadata:
   user-invocable: "false"

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -2,6 +2,7 @@
 name: ctf-misc
 description: Miscellaneous CTF challenge techniques. Use for encoding puzzles, RF/SDR signal processing, Python/bash jails, DNS exploitation, unicode steganography, floating-point tricks, QR codes, audio challenges, Z3 constraint solving, Kubernetes RBAC, WASM game patching, esoteric languages, or challenges that don't fit other categories.
 license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
 metadata:
   user-invocable: "false"
@@ -191,7 +192,7 @@ new_data = sha.extend(b'extension', b'original_message', len_secret, known_hash_
 
 ## Discord API Enumeration (0xFun 2026)
 
-Flags hidden in Discord metadata (roles, animated emoji, embeds). See [ctf-osint social-media.md](/Users/lcf/.agents/skills/ctf-osint/social-media.md#discord-api-enumeration) for full technique and code.
+Flags hidden in Discord metadata (roles, animated emoji, embeds). Invoke `/ctf-osint` and see social-media.md for Discord API enumeration technique and code.
 
 ---
 

--- a/ctf-osint/SKILL.md
+++ b/ctf-osint/SKILL.md
@@ -2,6 +2,7 @@
 name: ctf-osint
 description: Open Source Intelligence techniques for CTF challenges. Use when gathering information from public sources, social media, geolocation, DNS records, username enumeration, reverse image search, Google dorking, Wayback Machine, Tor relays, FEC filings, or identifying unknown data like hashes and coordinates.
 license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash and internet access for OSINT lookups.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
 metadata:
   user-invocable: "false"

--- a/ctf-pwn/SKILL.md
+++ b/ctf-pwn/SKILL.md
@@ -2,6 +2,7 @@
 name: ctf-pwn
 description: Binary exploitation (pwn) techniques for CTF challenges. Use when exploiting buffer overflows, format strings, heap vulnerabilities, race conditions, kernel bugs, ROP chains, ret2libc, shellcode, GOT overwrite, use-after-free, seccomp bypass, or sandbox escape.
 license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
 metadata:
   user-invocable: "false"

--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -2,6 +2,7 @@
 name: ctf-reverse
 description: Reverse engineering techniques for CTF challenges. Use when analyzing binaries, game clients, obfuscated code, esoteric languages, custom VMs, anti-debugging, WASM, .NET, APK, Python bytecode, Ghidra, GDB, radare2, or extracting flags from compiled executables.
 license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
 metadata:
   user-invocable: "false"

--- a/ctf-web/SKILL.md
+++ b/ctf-web/SKILL.md
@@ -2,6 +2,7 @@
 name: ctf-web
 description: Web exploitation techniques for CTF challenges. Use when solving web security challenges involving XSS, SQLi, SSTI, SSRF, CSRF, XXE, file upload bypasses, JWT attacks, prototype pollution, path traversal, command injection, request smuggling, DOM clobbering, Web3/blockchain, or authentication bypass.
 license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
 metadata:
   user-invocable: "false"

--- a/solve-challenge/SKILL.md
+++ b/solve-challenge/SKILL.md
@@ -2,6 +2,7 @@
 name: solve-challenge
 description: Solve CTF challenges by analyzing files, connecting to services, and applying exploitation techniques. Orchestrates category-specific CTF skills for pwn, crypto, web, reverse engineering, forensics, OSINT, malware analysis, and miscellaneous challenges.
 license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access. Orchestrates other ctf-* skills.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch Skill
 metadata:
   user-invocable: "true"
@@ -64,7 +65,7 @@ Once you identify the category, **invoke the matching skill** to get specialized
 | Malware | `/ctf-malware` | Obfuscated scripts, C2 traffic, PE/.NET analysis |
 | Misc | `/ctf-misc` | Jails, encodings, RF/SDR, esoteric languages, constraint solving |
 
-You can also read skill files directly for detailed techniques: `~/.agents/skills/ctf-<category>/SKILL.md`
+You can also invoke `/ctf-<category>` to load the full skill instructions with detailed techniques.
 
 ### Step 4: Pivot When Stuck
 


### PR DESCRIPTION
## Summary
- Add `compatibility` field to all 9 SKILL.md frontmatters declaring filesystem agent + bash + internet requirements per spec best practices
- Fix hardcoded absolute path in ctf-misc (machine-specific `/Users/...`)
- Fix assumed install path in solve-challenge (`~/.agents/skills/...`)
- Add `.gitignore` with `.claude/worktrees` entry

## Test plan
- All 9 skills pass official `skills-ref validate` after changes
- All file references verified to resolve correctly