### PR TITLE
Fix skill spec compliance issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ctf-skills
 
-[Agent skills](https://github.com/anthropics/agent-skills-spec) for solving CTF challenges — web exploitation, binary pwn, crypto, reverse engineering, forensics, OSINT, and more. Works with any tool that supports the Agent Skills spec, including [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+[Agent Skills](https://agentskills.io) for solving CTF challenges — web exploitation, binary pwn, crypto, reverse engineering, forensics, OSINT, and more. Works with any tool that supports the Agent Skills spec, including [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 
 ## Installation
 

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -3,7 +3,7 @@ name: ctf-misc
 description: Miscellaneous CTF challenge techniques. Use for encoding puzzles, RF/SDR signal processing, Python/bash jails, DNS exploitation, unicode steganography, floating-point tricks, QR codes, audio challenges, Z3 constraint solving, Kubernetes RBAC, WASM game patching, esoteric languages, or challenges that don't fit other categories.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
-allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
+allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch Skill
 metadata:
   user-invocable: "false"
 ---
@@ -192,7 +192,7 @@ new_data = sha.extend(b'extension', b'original_message', len_secret, known_hash_
 
 ## Discord API Enumeration (0xFun 2026)
 
-Flags hidden in Discord metadata (roles, animated emoji, embeds). Invoke `/ctf-osint` and see social-media.md for Discord API enumeration technique and code.
+Flags hidden in Discord metadata (roles, animated emoji, embeds). Invoke `/ctf-osint` and see [ctf-osint social-media.md](../ctf-osint/social-media.md) for Discord API enumeration technique and code.
 
 ---
 

--- a/ctf-osint/SKILL.md
+++ b/ctf-osint/SKILL.md
@@ -2,7 +2,7 @@
 name: ctf-osint
 description: Open Source Intelligence techniques for CTF challenges. Use when gathering information from public sources, social media, geolocation, DNS records, username enumeration, reverse image search, Google dorking, Wayback Machine, Tor relays, FEC filings, or identifying unknown data like hashes and coordinates.
 license: MIT
-compatibility: Requires filesystem-based agent (Claude Code or similar) with bash and internet access for OSINT lookups.
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for OSINT lookups.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
 metadata:
   user-invocable: "false"

--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -147,7 +147,7 @@ wasm2wat main.wasm -o main.wat    # Binary → text
 wat2wasm main.wat -o patched.wasm # Text → binary
 ```
 
-**WASM game patching (Tac Tic Toe, Pragyan 2026):** If proof generation is independent of move quality, patch minimax (flip `i64.lt_s` → `i64.gt_s`, change bestScore sign) to make AI play badly while proofs remain valid. See ctf-misc SKILL.md for full pattern.
+**WASM game patching (Tac Tic Toe, Pragyan 2026):** If proof generation is independent of move quality, patch minimax (flip `i64.lt_s` → `i64.gt_s`, change bestScore sign) to make AI play badly while proofs remain valid. See [ctf-misc games-and-vms.md](../ctf-misc/games-and-vms.md) for full pattern.
 
 ### Android APK
 ```bash


### PR DESCRIPTION
## Summary

- **ctf-misc**: Add `Skill` to `allowed-tools` — the skill instructs agents to invoke `/ctf-osint` but was missing the required tool declaration
- **ctf-misc**: Fix cross-skill reference to ctf-osint `social-media.md` to use a proper markdown link
- **ctf-osint**: Add `Python 3` to `compatibility` field — supporting files contain Python code (Unicode analysis, coordinate conversion, etc.)
- **ctf-reverse**: Fix cross-skill reference from plain text "See ctf-misc SKILL.md" to a proper relative markdown link
- **README**: Update Agent Skills spec link from old `github.com/anthropics/agent-skills-spec` to canonical `agentskills.io` URL

## Test plan

- [ ] Verify all skills pass `skills-ref validate` (frontmatter fields, name/directory match, field constraints)
- [ ] Confirm cross-skill markdown links resolve correctly
- [ ] Confirm `/ctf-osint` invocation from ctf-misc works with Skill tool now declared