### PR TITLE
Add reverse engineering docs for UPX, Tauri, Unity, Pyarmor, Flutter, and HarmonyOS

### DIFF
--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-reverse
-description: Provides reverse engineering techniques for CTF challenges. Use when analyzing binaries, game clients, obfuscated code, esoteric languages, custom VMs, anti-debugging, WASM, .NET, APK, Python bytecode, Ghidra, GDB, radare2, or extracting flags from compiled executables.
+description: Provides reverse engineering techniques for CTF challenges. Use when analyzing binaries, game clients, obfuscated code, esoteric languages, custom VMs, anti-debugging, WASM, .NET, APK (including Flutter/Dart AOT with Blutter), Python bytecode, Ghidra, GDB, radare2, or extracting flags from compiled executables.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
@@ -158,6 +158,24 @@ jadx app.apk                     # Decompile to Java
 grep -r "flag" decoded/res/values/strings.xml
 ```
 
+### Flutter APK (Dart AOT)
+
+When APK analysis points to Flutter (`lib/arm64-v8a/libapp.so`, `libflutter.so`), use Blutter first.
+
+- Blutter repository and docs: https://github.com/worawit/blutter
+
+```bash
+# Example workflow (APK -> libs -> Blutter output)
+python3 blutter.py path/to/app/lib/arm64-v8a out_dir
+```
+Output files
+- asm/* libapp assemblies with symbols
+- blutter_frida.js the frida script template for the target application
+- objs.txt complete (nested) dump of Object from Object Pool
+- pp.txt all Dart objects in Object Pool
+
+Blutter reconstructs Dart metadata and generates script output that is easier to navigate than raw ARM64 disassembly.
+
 ### .NET
 - dnSpy - debugging + decompilation
 - ILSpy - decompiler
@@ -166,6 +184,21 @@ grep -r "flag" decoded/res/values/strings.xml
 ```bash
 upx -d packed -o unpacked
 ```
+If unpacking fails, inspect UPX metadata first: verify UPX section names, header fields, and version markers are intact. If metadata looks tampered or uncertain, review UPX source on GitHub to identify likely modification points. 
+
+### Tauri Packed Desktop Apps (Static Assets)
+
+Tauri often embeds frontend assets directly into the executable, commonly Brotli-compressed by default.
+
+Workflow:
+1. Identify Tauri app traits (`tauri`, `wry`, `index.html`, webview-related strings).
+2. In disassembler, pivot from `index.html` string xrefs to locate the asset index table.
+3. Recover each asset record (filename + blob offset + blob length; exact layout varies by build/version).
+4. Dump blob bytes from the binary and attempt Brotli decompression first.
+5. If decompression fails, re-check exact boundaries; Brotli is highly sensitive to off-by-one errors.
+
+Reference points:
+- Tauri embedded assets implementation: `tauri-codegen/src/embedded_assets.rs`
 
 ## Anti-Debugging Bypass
 

--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-reverse
-description: Provides reverse engineering techniques for CTF challenges. Use when analyzing binaries, game clients, obfuscated code, esoteric languages, custom VMs, anti-debugging, WASM, .NET, APK (including Flutter/Dart AOT with Blutter), Python bytecode, Ghidra, GDB, radare2, or extracting flags from compiled executables.
+description: Provides reverse engineering techniques for CTF challenges. Use when analyzing binaries, game clients, obfuscated code, esoteric languages, custom VMs, anti-debugging, WASM, .NET, APK (including Flutter/Dart AOT with Blutter), HarmonyOS HAP/ABC, Python bytecode, Ghidra, GDB, radare2, or extracting flags from compiled executables.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
@@ -18,7 +18,7 @@ Quick reference for RE challenges. For detailed techniques, see supporting files
 - [patterns.md](patterns.md) - Foundational binary patterns: custom VMs, anti-debugging, nanomites, self-modifying code, XOR ciphers, mixed-mode stagers, LLVM obfuscation, S-box/keystream, SECCOMP/BPF, exception handlers, memory dumps, byte-wise transforms, x86-64 gotchas, signal-based exploration, malware anti-analysis, multi-stage shellcode, timing side-channel, multi-thread anti-debug with decoy + signal handler MBA
 - [patterns-ctf.md](patterns-ctf.md) - Competition-specific patterns (Part 1): hidden emulator opcodes, LD_PRELOAD key extraction, SPN static extraction, image XOR smoothness, byte-at-a-time cipher, mathematical convergence bitmap, Windows PE XOR bitmap OCR, two-stage RC4+VM loaders, GBA ROM meet-in-the-middle, Sprague-Grundy game theory, kernel module maze solving, multi-threaded VM channels, backdoored shared library detection via string diffing
 - [patterns-ctf-2.md](patterns-ctf-2.md) - Competition-specific patterns (Part 2): multi-layer self-decrypting brute-force, embedded ZIP+XOR license, stack string deobfuscation, prefix hash brute-force, CVP/LLL lattice for integer validation, decision tree function obfuscation, GLSL shader VM, GF(2^8) Gaussian elimination, Z3 single-line Python circuit, sliding window popcount
-- [languages.md](languages.md) - Language/platform-specific: Python bytecode & opcode remapping, Python version-specific bytecode, DOS stubs, Unity IL2CPP, Brainfuck/esolangs, UEFI, transpilation to C, code coverage side-channel, OPAL functional reversing, non-bijective substitution, Android JNI RegisterNatives, Ruby/Perl polyglot, Electron ASAR extraction + native binary analysis, Node.js npm runtime introspection
+- [languages.md](languages.md) - Language/platform-specific: Python bytecode & opcode remapping, Python version-specific bytecode, Pyarmor static unpack, DOS stubs, Unity IL2CPP, HarmonyOS HAP/ABC, Brainfuck/esolangs, UEFI, transpilation to C, code coverage side-channel, OPAL functional reversing, non-bijective substitution, Android JNI RegisterNatives, Ruby/Perl polyglot, Electron ASAR extraction + native binary analysis, Node.js npm runtime introspection
 
 ---
 

--- a/ctf-reverse/languages.md
+++ b/ctf-reverse/languages.md
@@ -7,6 +7,7 @@
 - [Python Opcode Remapping](#python-opcode-remapping)
   - [Identification](#identification)
   - [Recovery](#recovery)
+- [Pyarmor 8/9 Static Unpack (1shot)](#pyarmor-89-static-unpack-1shot)
 - [DOS Stub Analysis](#dos-stub-analysis)
 - [Unity IL2CPP Games](#unity-il2cpp-games)
 - [Brainfuck/Esolangs](#brainfuckesolangs)
@@ -67,6 +68,36 @@ Decompiler fails with opcode errors.
 3. Build mapping: `{new_opcode: original_opcode}`
 4. Patch target .pyc
 5. Decompile normally
+
+---
+
+## Pyarmor 8/9 Static Unpack (1shot)
+
+- Tool: `Lil-House/Pyarmor-Static-Unpack-1shot`
+- Use for Pyarmor 8.x/9.x armored scripts without executing sample code
+- Quick signature check: payload typically starts with `PY` + six digits (Pyarmor 7 and earlier `PYARMOR` format is not supported)
+
+Workflow:
+1. Ensure target directory contains armored scripts and matching `pyarmor_runtime` library.
+2. Run one-shot unpack to emit `.1shot.` outputs (disassembly + experimental decompile).
+3. Treat disassembly as ground truth; verify decompiled source with bytecode when inconsistent.
+
+```bash
+python /path/to/oneshot/shot.py /path/to/scripts
+```
+
+Optional flags:
+```bash
+# Specify runtime explicitly
+python /path/to/oneshot/shot.py /path/to/scripts -r /path/to/pyarmor_runtime.so
+
+# Write outputs to another directory
+python /path/to/oneshot/shot.py /path/to/scripts -o /path/to/output
+```
+
+Notes:
+- `oneshot/pyarmor-1shot` executable must exist before running `shot.py`.
+- PyInstaller bundles or archives should be unpacked first, then processed with 1shot.
 
 ---
 

--- a/ctf-reverse/languages.md
+++ b/ctf-reverse/languages.md
@@ -83,10 +83,12 @@ PE files can hide code in DOS stub:
 ## Unity IL2CPP Games
 
 - Use Il2CppDumper to dump symbols
+- If Il2CppDumper fails, consider that `global-metadata.dat` may be encrypted; search strings/xrefs in the main binary and inspect the metadata loading path for custom decryption before dump.
 - Look for `Start()` functions
 - Key derivation: `key = SHA256(companyName + "\n" + productName)`
 - Decrypt server responses with derived key
 
+Please note most of that the executable file for the PC platform is GameAssembly.dll or *Assembly.dll, for the Android is libil2cpp.so.
 ---
 
 ## Brainfuck/Esolangs

--- a/ctf-reverse/languages.md
+++ b/ctf-reverse/languages.md
@@ -10,6 +10,7 @@
 - [Pyarmor 8/9 Static Unpack (1shot)](#pyarmor-89-static-unpack-1shot)
 - [DOS Stub Analysis](#dos-stub-analysis)
 - [Unity IL2CPP Games](#unity-il2cpp-games)
+- [HarmonyOS HAP/ABC Reverse (abc-decompiler)](#harmonyos-hapabc-reverse-abc-decompiler)
 - [Brainfuck/Esolangs](#brainfuckesolangs)
 - [UEFI Binary Analysis](#uefi-binary-analysis)
 - [Transpilation to C](#transpilation-to-c)
@@ -120,6 +121,58 @@ PE files can hide code in DOS stub:
 - Decrypt server responses with derived key
 
 Please note most of that the executable file for the PC platform is GameAssembly.dll or *Assembly.dll, for the Android is libil2cpp.so.
+
+---
+
+## HarmonyOS HAP/ABC Reverse (abc-decompiler)
+
+- Target files: `.hap` package and embedded `.abc` bytecode
+- Tool: `https://github.com/ohos-decompiler/abc-decompiler`
+- Download `jadx-dev-all.jar` from releases
+
+Critical startup note:
+- `java -jar` may enter GUI mode
+- For CLI mode, always use:
+
+```bash
+java -cp "./jadx-dev-all.jar" jadx.cli.JadxCLI [options] <input>
+```
+
+Most common commands:
+```bash
+# Basic decompile to directory
+java -cp "./jadx-dev-all.jar" jadx.cli.JadxCLI -d "out" ".abc"
+
+# Decompile .abc (recommended for this scenario)
+java -cp "./jadx-dev-all.jar" jadx.cli.JadxCLI -m simple -d "out_hap" "modules.abc"
+```
+
+Recommended parameters for this challenge:
+- `-m simple`: reduce high-level reconstruction to avoid SSA/PHI-heavy failures
+- `--log-level ERROR`: keep only critical errors
+- Full recommended command:
+
+```bash
+java -cp "./jadx-dev-all.jar" jadx.cli.JadxCLI -m simple --log-level ERROR -d "out_abc_simple" "modules.abc"
+```
+
+Parameter quick reference:
+- `-d` output directory
+- `--help` help
+
+Notes:
+- `.hap` is a package: extract it first (zip), then locate and analyze `.abc`
+- Quote paths containing spaces or non-ASCII characters
+- Use a new output directory name per run to avoid stale results
+- Errors do not always mean full failure; prioritize `out_xxx/sources/`
+- If `auto` fails, switch to `-m simple` first
+
+Standard workflow:
+1. Run with `-m simple --log-level ERROR`
+2. Inspect key business files in output (for example `pages/Index.java`)
+3. If cleaner output is needed, retry with `-m auto` or `-m restructure`
+4. If some methods still fail, keep the `simple` output and continue logic analysis via alternate paths
+
 ---
 
 ## Brainfuck/Esolangs

--- a/ctf-reverse/tools.md
+++ b/ctf-reverse/tools.md
@@ -28,6 +28,7 @@
   - [Extraction](#extraction)
   - [Key Locations](#key-locations)
   - [Search](#search)
+  - [Flutter APK (Blutter)](#flutter-apk-blutter)
 - [.NET Analysis](#net-analysis)
   - [Tools](#tools)
   - [NativeAOT](#nativeaot)
@@ -283,6 +284,13 @@ unzip app.apk -d extracted/      # Simple extraction
 ```bash
 grep -r "flag\|CTF" decoded/
 strings decoded/classes*.dex | grep -i flag
+```
+
+### Flutter APK (Blutter)
+
+```bash
+# Run Blutter on arm64 build
+python3 blutter.py path/to/app/lib/arm64-v8a out_dir
 ```
 
 ---

--- a/ctf-reverse/tools.md
+++ b/ctf-reverse/tools.md
@@ -21,6 +21,7 @@
 - [Python Bytecode](#python-bytecode)
   - [Disassembly](#disassembly)
   - [Extract Constants](#extract-constants)
+  - [Pyarmor Static Unpack (1shot)](#pyarmor-static-unpack-1shot)
 - [WASM Analysis](#wasm-analysis)
   - [Decompile to C](#decompile-to-c)
   - [Common Patterns](#common-patterns)
@@ -247,6 +248,27 @@ for ins in dis.get_instructions(code):
     if ins.opname == 'LOAD_CONST':
         print(ins.argval)
 ```
+
+### Pyarmor Static Unpack (1shot)
+
+Repository: `https://github.com/Lil-House/Pyarmor-Static-Unpack-1shot`
+
+```bash
+# Basic usage (recursive processing)
+python /path/to/oneshot/shot.py /path/to/scripts
+
+# Specify pyarmor runtime library explicitly
+python /path/to/oneshot/shot.py /path/to/scripts -r /path/to/pyarmor_runtime.so
+
+# Save outputs to another directory
+python /path/to/oneshot/shot.py /path/to/scripts -o /path/to/output
+```
+
+Notes:
+- `oneshot/pyarmor-1shot` must exist before running `shot.py`.
+- Supported focus: Pyarmor 8.x-9.x (`PY` + six digits header style).
+- Pyarmor 7 and earlier (`PYARMOR` header) are out of scope.
+- Disassembly output is generally reliable; decompiled source is experimental.
 
 ---
 

--- a/ctf-reverse/tools.md
+++ b/ctf-reverse/tools.md
@@ -30,6 +30,7 @@
   - [Key Locations](#key-locations)
   - [Search](#search)
   - [Flutter APK (Blutter)](#flutter-apk-blutter)
+  - [HarmonyOS HAP/ABC (abc-decompiler)](#harmonyos-hapabc-abc-decompiler)
 - [.NET Analysis](#net-analysis)
   - [Tools](#tools)
   - [NativeAOT](#nativeaot)
@@ -314,6 +315,36 @@ strings decoded/classes*.dex | grep -i flag
 # Run Blutter on arm64 build
 python3 blutter.py path/to/app/lib/arm64-v8a out_dir
 ```
+
+### HarmonyOS HAP/ABC (abc-decompiler)
+
+Repository: `https://github.com/ohos-decompiler/abc-decompiler`
+Releases: `https://github.com/ohos-decompiler/abc-decompiler/releases/download/h1/jadx-dev-all.jar`
+
+```bash
+# Extract .hap first to obtain .abc files
+unzip app.hap -d hap_extracted/
+```
+
+Critical startup mode:
+```bash
+# Use CLI entrypoint (avoid java -jar GUI mode)
+java -cp "./jadx-dev-all.jar" jadx.cli.JadxCLI [options] <input>
+```
+
+```bash
+# Basic decompile
+java -cp "./jadx-dev-all.jar" jadx.cli.JadxCLI -d "out" ".abc"
+
+# Recommended for .abc
+java -cp "./jadx-dev-all.jar" jadx.cli.JadxCLI -m simple --log-level ERROR -d "out_abc_simple" ".abc"
+```
+
+Notes:
+- Start with `-m simple --log-level ERROR`.
+- If `auto` fails, retry with `-m simple` first.
+- Errors do not always mean total failure; check `out_xxx/sources/`.
+- Use a fresh output directory per run.
 
 ---
 

--- a/ctf-reverse/tools.md
+++ b/ctf-reverse/tools.md
@@ -319,7 +319,6 @@ python3 blutter.py path/to/app/lib/arm64-v8a out_dir
 ### HarmonyOS HAP/ABC (abc-decompiler)
 
 Repository: `https://github.com/ohos-decompiler/abc-decompiler`
-Releases: `https://github.com/ohos-decompiler/abc-decompiler/releases/download/h1/jadx-dev-all.jar`
 
 ```bash
 # Extract .hap first to obtain .abc files


### PR DESCRIPTION
This PR updates reverse-engineering skills documentation with new practical coverage for:
- UPX unpacking failure triage
- Tauri static asset extraction
- Unity IL2CPP fallback note (`global-metadata.dat` encryption checks)
- Pyarmor 8/9 static unpack (1shot)
- Flutter reverse workflow (Blutter)
- HarmonyOS `.hap` / `.abc` reverse workflow (`abc-decompiler` CLI usage)