### PR TITLE
Add Go/Rust reversing, Frida, angr, lldb, x64dbg to ctf-reverse

### DIFF
--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ctf-reverse
-description: Provides reverse engineering techniques for CTF challenges. Use when analyzing binaries, game clients, obfuscated code, esoteric languages, custom VMs, anti-debugging, WASM, .NET, APK (including Flutter/Dart AOT with Blutter), HarmonyOS HAP/ABC, Python bytecode, Ghidra, GDB, radare2, or extracting flags from compiled executables.
+description: Provides reverse engineering techniques for CTF challenges. Use when analyzing binaries, game clients, obfuscated code, esoteric languages, custom VMs, anti-debugging, WASM, .NET, APK (including Flutter/Dart AOT with Blutter), HarmonyOS HAP/ABC, Python bytecode, Go binaries, Rust binaries, Ghidra, GDB, radare2, Frida, angr, or extracting flags from compiled executables.
 license: MIT
 compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
 allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
@@ -14,11 +14,11 @@ Quick reference for RE challenges. For detailed techniques, see supporting files
 
 ## Additional Resources
 
-- [tools.md](tools.md) - Tool-specific commands (GDB, Ghidra, radare2, IDA, Binary Ninja, dogbolt.org, RISC-V with Capstone)
+- [tools.md](tools.md) - Tool-specific commands (GDB, Ghidra, radare2, IDA, Binary Ninja, dogbolt.org, RISC-V with Capstone, Frida dynamic instrumentation, angr symbolic execution, lldb, x64dbg)
 - [patterns.md](patterns.md) - Foundational binary patterns: custom VMs, anti-debugging, nanomites, self-modifying code, XOR ciphers, mixed-mode stagers, LLVM obfuscation, S-box/keystream, SECCOMP/BPF, exception handlers, memory dumps, byte-wise transforms, x86-64 gotchas, signal-based exploration, malware anti-analysis, multi-stage shellcode, timing side-channel, multi-thread anti-debug with decoy + signal handler MBA
 - [patterns-ctf.md](patterns-ctf.md) - Competition-specific patterns (Part 1): hidden emulator opcodes, LD_PRELOAD key extraction, SPN static extraction, image XOR smoothness, byte-at-a-time cipher, mathematical convergence bitmap, Windows PE XOR bitmap OCR, two-stage RC4+VM loaders, GBA ROM meet-in-the-middle, Sprague-Grundy game theory, kernel module maze solving, multi-threaded VM channels, backdoored shared library detection via string diffing
 - [patterns-ctf-2.md](patterns-ctf-2.md) - Competition-specific patterns (Part 2): multi-layer self-decrypting brute-force, embedded ZIP+XOR license, stack string deobfuscation, prefix hash brute-force, CVP/LLL lattice for integer validation, decision tree function obfuscation, GLSL shader VM, GF(2^8) Gaussian elimination, Z3 single-line Python circuit, sliding window popcount
-- [languages.md](languages.md) - Language/platform-specific: Python bytecode & opcode remapping, Python version-specific bytecode, Pyarmor static unpack, DOS stubs, Unity IL2CPP, HarmonyOS HAP/ABC, Brainfuck/esolangs, UEFI, transpilation to C, code coverage side-channel, OPAL functional reversing, non-bijective substitution, Roblox place file analysis, Godot game asset extraction, Rust serde_json schema recovery, Verilog/hardware RE, Android JNI RegisterNatives, Ruby/Perl polyglot, Electron ASAR extraction + native binary analysis, Node.js npm runtime introspection
+- [languages.md](languages.md) - Language/platform-specific: Python bytecode & opcode remapping, Python version-specific bytecode, Pyarmor static unpack, DOS stubs, Unity IL2CPP, HarmonyOS HAP/ABC, Brainfuck/esolangs, UEFI, transpilation to C, code coverage side-channel, OPAL functional reversing, non-bijective substitution, Roblox place file analysis, Godot game asset extraction, Rust serde_json schema recovery, Verilog/hardware RE, Android JNI RegisterNatives, Ruby/Perl polyglot, Electron ASAR extraction + native binary analysis, Node.js npm runtime introspection, Go binary reversing (GoReSym, goroutines, memory layout), Rust binary reversing (demangling, Option/Result, iterators, panic strings)
 
 ---
 
@@ -26,9 +26,11 @@ Quick reference for RE challenges. For detailed techniques, see supporting files
 
 1. **Start with strings extraction** - many easy challenges have plaintext flags
 2. **Try ltrace/strace** - dynamic analysis often reveals flags without reversing
-3. **Map control flow** before modifying execution
-4. **Automate manual processes** via scripting (r2pipe, Python)
-5. **Validate assumptions** by comparing decompiler outputs
+3. **Try Frida hooking** - hook strcmp/memcmp to capture expected values without reversing
+4. **Try angr** - symbolic execution solves many flag-checkers automatically
+5. **Map control flow** before modifying execution
+6. **Automate manual processes** via scripting (r2pipe, Frida, angr, Python)
+7. **Validate assumptions** by comparing decompiler outputs
 
 ## Quick Wins (Try First!)
 
@@ -402,3 +404,19 @@ N-layer binary where each layer decrypts the next using user-provided key bytes 
 ## Backdoored Shared Library Detection
 
 Binary works in GDB but fails when run normally (suid)? Check `ldd` for non-standard libc paths, then `strings | diff` the suspicious vs. system library to find injected code/passwords. See [patterns-ctf.md](patterns-ctf.md#backdoored-shared-library-detection-via-string-diffing-hacklu-ctf-2012).
+
+## Go Binary Reversing
+
+Large static binary with `go.buildid`? Use GoReSym to recover function names (works even on stripped binaries). Go strings are `{ptr, len}` pairs — not null-terminated. Look for `main.main`, `runtime.gopanic`, channel ops (`runtime.chansend1`/`chanrecv1`). Use Ghidra golang-loader plugin for best results. See [languages.md](languages.md#go-binary-reversing).
+
+## Rust Binary Reversing
+
+Binary with `core::panicking` strings and `_ZN` mangled symbols? Use `rustfilt` for demangling. Panic messages contain source paths and line numbers — `strings binary | grep "panicked"` is the fastest approach. Option/Result enums use discriminant byte (0=None/Err, 1=Some/Ok). See [languages.md](languages.md#rust-binary-reversing).
+
+## Frida Dynamic Instrumentation
+
+Hook runtime functions without modifying binary. `frida -f ./binary -l hook.js` to spawn with instrumentation. Hook `strcmp`/`memcmp` to capture expected values, bypass anti-debug by replacing `ptrace` return value, scan memory for flag patterns, replace validation functions. See [tools.md](tools.md#frida-dynamic-instrumentation).
+
+## angr Symbolic Execution
+
+Automatic path exploration to find inputs satisfying constraints. Load binary with `angr.Project`, set find/avoid addresses, call `simgr.explore()`. Constrain input to printable ASCII and known prefix for faster solving. Hook expensive functions (crypto, I/O) to prevent path explosion. See [tools.md](tools.md#angr-symbolic-execution).

--- a/ctf-reverse/languages.md
+++ b/ctf-reverse/languages.md
@@ -27,6 +27,8 @@
 - [Ruby/Perl Polyglot Constraint Satisfaction (BearCatCTF 2026)](#rubyperl-polyglot-constraint-satisfaction-bearcatctf-2026)
 - [Electron App + Native Binary Reversing (RootAccess2026)](#electron-app--native-binary-reversing-rootaccess2026)
 - [Node.js npm Package Runtime Introspection (RootAccess2026)](#nodejs-npm-package-runtime-introspection-rootaccess2026)
+- [Go Binary Reversing](#go-binary-reversing)
+- [Rust Binary Reversing](#rust-binary-reversing)
 
 ---
 
@@ -615,3 +617,270 @@ console.log('Hidden methods:', hidden);
 **Key insight:** Heavily obfuscated JavaScript (control flow flattening, RC4 string encoding, dead code) makes static analysis prohibitively slow. Runtime introspection via `Object.getOwnPropertyNames()` reveals all methods including hidden ones. The module's own decryption runs automatically when loaded — just call the decoded functions directly.
 
 **Detection:** npm package with minified/obfuscated `dist/` directory, challenge says "reverse engineer the CLI tool", `package.json` with custom commands.
+
+---
+
+## Go Binary Reversing
+
+Go binaries are increasingly common in CTF challenges due to Go's popularity for CLI tools, network services, and malware.
+
+### Recognition
+
+```bash
+# Detect Go binary
+file binary | grep -i "go"
+strings binary | grep "go.buildid"
+strings binary | grep "runtime.gopanic"
+
+# Go version embedded in binary
+strings binary | grep "^go1\."
+```
+
+**Key indicators:**
+- Very large static binary (even "hello world" is ~2MB)
+- Embedded `go.buildid` string
+- `runtime.*` symbols (even in stripped binaries, some remain)
+- `main.main` as entry point (not `main`)
+- Strings like `GOROOT`, `GOPATH`, `/usr/local/go/src/`
+
+### Symbol Recovery
+
+Go embeds rich type and function information even in stripped binaries:
+
+```bash
+# GoReSym - recovers function names, types, interfaces from Go binaries
+# https://github.com/mandiant/GoReSym
+./GoReSym -d binary > symbols.json
+
+# Parse output
+python3 -c "
+import json
+with open('symbols.json') as f:
+    data = json.load(f)
+for fn in data.get('UserFunctions', []):
+    print(f\"{fn['Start']:#x}  {fn['FullName']}\")
+"
+```
+
+**Ghidra with golang-loader:**
+```bash
+# Install: Ghidra → Window → Script Manager → search "golang"
+# Or use: https://github.com/getCUJO/ThreatFox/tree/main/ghidra-golang
+# Recovers function names, string references, interface tables
+```
+
+**redress (Go binary analysis):**
+```bash
+# https://github.com/goretk/redress
+redress -src binary         # Reconstruct source tree
+redress -pkg binary         # List packages
+redress -type binary        # List types and methods
+redress -interface binary   # List interfaces
+```
+
+### Go Memory Layout
+
+Understanding Go's data structures in decompilation:
+
+```
+# String: {pointer, length} (16 bytes on 64-bit)
+# NOT null-terminated! Length field is critical.
+struct GoString {
+    char *ptr;    // pointer to UTF-8 data
+    int64 len;    // byte length
+};
+
+# Slice: {pointer, length, capacity} (24 bytes on 64-bit)
+struct GoSlice {
+    void *ptr;    // pointer to backing array
+    int64 len;    // current length
+    int64 cap;    // allocated capacity
+};
+
+# Interface: {type_descriptor, data_pointer} (16 bytes)
+struct GoInterface {
+    void *type;   // points to type metadata (itab for non-empty interface)
+    void *data;   // points to actual value
+};
+
+# Map: pointer to runtime.hmap struct
+# Channel: pointer to runtime.hchan struct
+```
+
+**In Ghidra/IDA:** When you see a function taking `(ptr, int64)` — it's likely a Go string. Three-field `(ptr, int64, int64)` is a slice.
+
+### Goroutine and Concurrency Analysis
+
+```bash
+# Identify goroutine spawns in disassembly
+strings binary | grep "runtime.newproc"
+# newproc1 is the internal goroutine creation function
+
+# In GDB with Go support:
+gdb ./binary
+(gdb) source /usr/local/go/src/runtime/runtime-gdb.py
+(gdb) info goroutines          # List all goroutines
+(gdb) goroutine 1 bt          # Backtrace for goroutine 1
+```
+
+**Channel operations in disassembly:**
+- `runtime.chansend1` → `ch <- value`
+- `runtime.chanrecv1` → `value = <-ch`
+- `runtime.selectgo` → `select { case ... }`
+- `runtime.closechan` → `close(ch)`
+
+### Common Go Patterns in Decompilation
+
+**Defer mechanism:**
+- `runtime.deferproc` → registers deferred function
+- `runtime.deferreturn` → executes deferred functions at function exit
+- Deferred calls execute in LIFO order — relevant for cleanup/crypto key wiping
+
+**Error handling (the `if err != nil` pattern):**
+```
+# In disassembly, this appears as:
+# call some_function        → returns (result, error) as two values
+# test rax, rax             → check if error (second return value) is nil
+# jne error_handler
+```
+
+**String concatenation:**
+- `runtime.concatstrings` → `s1 + s2 + s3`
+- `fmt.Sprintf` → formatted string building
+- Look for format strings in `.rodata`: `"%s%d"`, `"%x"`
+
+**Common stdlib patterns in CTF:**
+```go
+// Crypto operations → look for these in strings/imports:
+// "crypto/aes", "crypto/cipher", "crypto/sha256", "encoding/hex", "encoding/base64"
+
+// Network operations:
+// "net/http", "net.Dial", "bufio.NewReader"
+
+// File operations:
+// "os.Open", "io.ReadAll", "os.ReadFile"
+```
+
+### Go Binary Reversing Workflow
+
+```
+1. file binary                          # Confirm Go, get arch
+2. GoReSym -d binary > syms.json       # Recover symbols
+3. strings binary | grep -i flag        # Quick win check
+4. Load in Ghidra with golang-loader    # Apply recovered symbols
+5. Find main.main                       # Entry point
+6. Identify string comparisons          # GoString {ptr, len} pairs
+7. Trace crypto operations              # crypto/* package usage
+8. Check for embedded resources         # embed.FS in Go 1.16+
+```
+
+**Go embed.FS (Go 1.16+):** Binaries can embed files at compile time:
+```bash
+# Look for embedded file data
+strings binary | grep "embed"
+# Embedded files appear as raw data in the binary
+# Search for known file signatures (PK for zip, PNG header, etc.)
+```
+
+**Key insight:** Go's runtime embeds extensive metadata even in stripped binaries. Use GoReSym before any manual analysis — it often recovers 90%+ of function names, making decompilation dramatically easier. Go strings are `{ptr, len}` tuples, not null-terminated — Ghidra's default string analysis will miss them without the golang-loader plugin.
+
+**Detection:** Large static binary (2MB+ for simple programs), `go.buildid`, `runtime.gopanic`, source paths like `/home/user/go/src/`.
+
+---
+
+## Rust Binary Reversing
+
+Rust binaries are common in modern CTFs, especially for crypto, systems, and security tooling challenges.
+
+### Recognition
+
+```bash
+# Detect Rust binary
+strings binary | grep -c "rust"
+strings binary | grep "rustc"             # Compiler version
+strings binary | grep "/rustc/"           # Source paths
+strings binary | grep "core::panicking"   # Panic infrastructure
+```
+
+**Key indicators:**
+- `core::panicking::panic` in strings
+- Mangled symbols starting with `_ZN` (Itanium ABI) — e.g., `_ZN4main4main17h...`
+- `.rustc` section in ELF
+- References to `/rustc/<commit_hash>/library/`
+- Large binary size (Rust statically links by default)
+
+### Symbol Demangling
+
+```bash
+# Rust uses Itanium ABI mangling (same as C++)
+# rustfilt demangles Rust-specific symbols
+cargo install rustfilt
+nm binary | rustfilt | grep "main"
+
+# Or use c++filt (works for most Rust symbols)
+nm binary | c++filt | grep "main"
+
+# In Ghidra: Window → Script Manager → search "Demangler"
+# Enable "DemangleAllScript" for automatic demangling
+```
+
+### Common Rust Patterns in Decompilation
+
+**Option/Result enum:**
+```
+# Option<T> in memory: {discriminant (0=None, 1=Some), value}
+# Result<T, E>: {discriminant (0=Ok, 1=Err), union{ok_val, err_val}}
+
+# In disassembly:
+# cmp byte [rbp-0x10], 0    → check if None/Err
+# je handle_none_case
+```
+
+**Vec<T> (same as Go slice):**
+```
+struct RustVec {
+    void *ptr;      // heap pointer
+    uint64 cap;     // capacity
+    uint64 len;     // length
+};
+```
+
+**String / &str:**
+```
+# String (owned): {ptr, capacity, length} — 24 bytes, heap-allocated
+# &str (borrowed): {ptr, length} — 16 bytes, can point anywhere
+
+# In decompilation, look for:
+# alloc::string::String::from    → String creation
+# core::str::from_utf8           → byte slice to str
+```
+
+**Iterator chains:**
+```
+# .iter().map().filter().collect() compiles to loop fusion
+# In disassembly: tight loop with inlined closures
+# Look for: core::iter::adapters::map, filter, etc.
+```
+
+**Panic unwinding:**
+```bash
+# Panic strings reveal source locations and error messages
+strings binary | grep "panicked at"
+strings binary | grep "called .unwrap().. on"
+# These often contain file paths, line numbers, and variable names
+```
+
+### Rust-Specific Analysis Tools
+
+```bash
+# cargo-bloat: analyze binary size by function
+cargo install cargo-bloat
+cargo bloat --release -n 50
+
+# Ghidra Rust helper scripts
+# https://github.com/AmateursCTF/ghidra-rust (community scripts for Rust RE)
+```
+
+**Key insight:** Rust panic messages are goldmines — they contain source file paths, line numbers, and descriptive error strings even in release builds. Always `strings binary | grep "panicked"` first. Rust's monomorphization means generic functions get duplicated per type — expect many similar-looking functions.
+
+**Detection:** `core::panicking`, `.rustc` section, `/rustc/` paths, `_ZN` mangled symbols with Rust-style module paths.

--- a/ctf-reverse/tools.md
+++ b/ctf-reverse/tools.md
@@ -44,6 +44,24 @@
 - [RISC-V Binary Analysis (EHAX 2026)](#risc-v-binary-analysis-ehax-2026)
 - [Binary Ninja](#binary-ninja)
 - [Decompiler Comparison with dogbolt.org](#decompiler-comparison-with-dogboltorg)
+- [Frida (Dynamic Instrumentation)](#frida-dynamic-instrumentation)
+  - [Basic Function Hooking](#basic-function-hooking)
+  - [Anti-Debug Bypass](#anti-debug-bypass)
+  - [Memory Scanning and Patching](#memory-scanning-and-patching)
+  - [Function Replacement](#function-replacement)
+  - [Tracing and Stalker](#tracing-and-stalker)
+  - [r2frida](#r2frida-radare2--frida-integration)
+  - [Frida for Android/iOS](#frida-for-androidios)
+- [angr (Symbolic Execution)](#angr-symbolic-execution)
+  - [Basic Path Exploration](#basic-path-exploration)
+  - [Symbolic Input with Constraints](#symbolic-input-with-constraints)
+  - [Hook Functions to Simplify Analysis](#hook-functions-to-simplify-analysis)
+  - [Exploring from Specific Address](#exploring-from-specific-address)
+  - [Common Patterns and Tips](#common-patterns-and-tips)
+  - [Dealing with Path Explosion](#dealing-with-path-explosion)
+  - [angr CFG Recovery](#angr-cfg-recovery)
+- [lldb (LLVM Debugger)](#lldb-llvm-debugger)
+- [x64dbg (Windows Debugger)](#x64dbg-windows-debugger)
 - [Useful Commands](#useful-commands)
 
 ---
@@ -515,6 +533,460 @@ curl -F "file=@binary" https://dogbolt.org/api/binaries/
 ```
 
 **Key insight:** Different decompilers excel at different constructs. When one produces unreadable output, another often generates clearer pseudocode. Cross-referencing catches decompiler bugs.
+
+---
+
+## Frida (Dynamic Instrumentation)
+
+Frida injects JavaScript into running processes for real-time hooking, tracing, and modification. Essential for anti-debug bypass, runtime inspection, and mobile RE.
+
+### Installation
+
+```bash
+pip install frida-tools frida
+# Verify
+frida --version
+```
+
+### Basic Function Hooking
+
+```javascript
+// hook.js — intercept a function and log arguments/return value
+Interceptor.attach(Module.findExportByName(null, "strcmp"), {
+    onEnter: function(args) {
+        this.arg0 = Memory.readUtf8String(args[0]);
+        this.arg1 = Memory.readUtf8String(args[1]);
+        console.log(`strcmp("${this.arg0}", "${this.arg1}")`);
+    },
+    onLeave: function(retval) {
+        console.log(`  → ${retval}`);
+    }
+});
+```
+
+```bash
+# Attach to running process
+frida -p $(pidof binary) -l hook.js
+
+# Spawn and instrument from start
+frida -f ./binary -l hook.js --no-pause
+
+# One-liner: hook strcmp and dump comparisons
+frida -f ./binary --no-pause -e '
+Interceptor.attach(Module.findExportByName(null, "strcmp"), {
+    onEnter(args) {
+        console.log("strcmp:", Memory.readUtf8String(args[0]), Memory.readUtf8String(args[1]));
+    }
+});
+'
+```
+
+### Anti-Debug Bypass
+
+```javascript
+// Bypass ptrace(PTRACE_TRACEME) — returns 0 (success) without calling
+Interceptor.attach(Module.findExportByName(null, "ptrace"), {
+    onEnter: function(args) {
+        this.request = args[0].toInt32();
+    },
+    onLeave: function(retval) {
+        if (this.request === 0) { // PTRACE_TRACEME
+            retval.replace(ptr(0));
+            console.log("[*] ptrace(TRACEME) bypassed");
+        }
+    }
+});
+
+// Bypass IsDebuggerPresent (Windows)
+var isDbg = Module.findExportByName("kernel32.dll", "IsDebuggerPresent");
+Interceptor.attach(isDbg, {
+    onLeave: function(retval) {
+        retval.replace(ptr(0));
+    }
+});
+
+// Bypass timing checks — hook clock_gettime to return constant
+Interceptor.attach(Module.findExportByName(null, "clock_gettime"), {
+    onLeave: function(retval) {
+        // Force constant timestamp to defeat timing checks
+        var ts = this.context.rsi || this.context.x1; // x86 or ARM
+        Memory.writeU64(ts, 0);        // tv_sec
+        Memory.writeU64(ts.add(8), 0); // tv_nsec
+    }
+});
+```
+
+### Memory Scanning and Patching
+
+```javascript
+// Scan for flag pattern in memory
+Process.enumerateRanges('r--').forEach(function(range) {
+    Memory.scan(range.base, range.size, "66 6c 61 67 7b", { // "flag{"
+        onMatch: function(address, size) {
+            console.log("[FLAG] Found at:", address, Memory.readUtf8String(address, 64));
+        },
+        onComplete: function() {}
+    });
+});
+
+// Patch instruction (NOP out a check)
+var addr = Module.findBaseAddress("binary").add(0x1234);
+Memory.patchCode(addr, 2, function(code) {
+    var writer = new X86Writer(code, { pc: addr });
+    writer.putNop();
+    writer.putNop();
+    writer.flush();
+});
+```
+
+### Function Replacement
+
+```javascript
+// Replace a validation function to always return true
+var checkFlag = Module.findExportByName(null, "check_flag");
+Interceptor.replace(checkFlag, new NativeCallback(function(input) {
+    console.log("[*] check_flag called with:", Memory.readUtf8String(input));
+    return 1; // always valid
+}, 'int', ['pointer']));
+```
+
+### Tracing and Stalker
+
+```javascript
+// Trace all calls in a function (Stalker — instruction-level tracing)
+var targetAddr = Module.findExportByName(null, "main");
+Stalker.follow(Process.getCurrentThreadId(), {
+    transform: function(iterator) {
+        var instruction;
+        while ((instruction = iterator.next()) !== null) {
+            if (instruction.mnemonic === "call") {
+                iterator.putCallout(function(context) {
+                    console.log("CALL at", context.pc, "→", ptr(context.pc).readPointer());
+                });
+            }
+            iterator.keep();
+        }
+    }
+});
+```
+
+### r2frida (Radare2 + Frida Integration)
+
+```bash
+# Attach radare2 to process via Frida
+r2 frida://spawn/./binary
+
+# r2frida commands
+\ii                    # List imports
+\il                    # List loaded modules
+\dt strcmp             # Trace strcmp calls
+\dc                    # Continue execution
+\dm                    # List memory maps
+```
+
+### Frida for Android/iOS
+
+```bash
+# Android (requires rooted device or Frida server)
+adb push frida-server /data/local/tmp/
+adb shell "chmod 755 /data/local/tmp/frida-server && /data/local/tmp/frida-server &"
+
+# Hook Android Java methods
+frida -U -f com.example.app -l hook_android.js --no-pause
+```
+
+```javascript
+// hook_android.js — hook Java method
+Java.perform(function() {
+    var MainActivity = Java.use("com.example.app.MainActivity");
+    MainActivity.checkPassword.implementation = function(input) {
+        console.log("[*] checkPassword called with:", input);
+        var result = this.checkPassword(input);
+        console.log("[*] Result:", result);
+        return result;
+    };
+});
+```
+
+**Key insight:** Frida excels where static analysis fails — obfuscated code, packed binaries, and runtime-generated data. Hook comparison functions (`strcmp`, `memcmp`, custom validators) to extract expected values without reversing the algorithm. Use `Interceptor.attach` for observation, `Interceptor.replace` for modification.
+
+**When to use:** Anti-debugging bypass, extracting runtime-computed keys, hooking crypto functions to dump plaintext, mobile app analysis, packed binary inspection.
+
+---
+
+## angr (Symbolic Execution)
+
+angr automatically explores program paths to find inputs satisfying constraints. Solves many flag-checking binaries in minutes that take hours manually.
+
+### Installation
+
+```bash
+pip install angr
+```
+
+### Basic Path Exploration
+
+```python
+import angr
+import claripy
+
+# Load binary
+proj = angr.Project('./binary', auto_load_libs=False)
+
+# Find address of "Correct!" print, avoid "Wrong!" print
+# Get these from disassembly (objdump -d or Ghidra)
+FIND_ADDR = 0x401234    # Address of success path
+AVOID_ADDR = 0x401256   # Address of failure path
+
+# Create simulation manager and explore
+simgr = proj.factory.simgr()
+simgr.explore(find=FIND_ADDR, avoid=AVOID_ADDR)
+
+if simgr.found:
+    found = simgr.found[0]
+    # Get stdin that reaches the target
+    print("Flag:", found.posix.dumps(0))  # fd 0 = stdin
+```
+
+### Symbolic Input with Constraints
+
+```python
+import angr
+import claripy
+
+proj = angr.Project('./binary', auto_load_libs=False)
+
+# Create symbolic input (e.g., 32-byte flag)
+flag_len = 32
+flag_chars = [claripy.BVS(f'flag_{i}', 8) for i in range(flag_len)]
+flag = claripy.Concat(*flag_chars + [claripy.BVV(b'\n')])
+
+# Constrain to printable ASCII
+state = proj.factory.entry_state(stdin=flag)
+for c in flag_chars:
+    state.solver.add(c >= 0x20)
+    state.solver.add(c <= 0x7e)
+
+# Constrain known prefix: "flag{"
+state.solver.add(flag_chars[0] == ord('f'))
+state.solver.add(flag_chars[1] == ord('l'))
+state.solver.add(flag_chars[2] == ord('a'))
+state.solver.add(flag_chars[3] == ord('g'))
+state.solver.add(flag_chars[4] == ord('{'))
+state.solver.add(flag_chars[flag_len-1] == ord('}'))
+
+simgr = proj.factory.simgr(state)
+simgr.explore(find=0x401234, avoid=0x401256)
+
+if simgr.found:
+    found = simgr.found[0]
+    result = found.solver.eval(flag, cast_to=bytes)
+    print("Flag:", result.decode())
+```
+
+### Hook Functions to Simplify Analysis
+
+```python
+import angr
+
+proj = angr.Project('./binary', auto_load_libs=False)
+
+# Hook printf to avoid path explosion in I/O
+@proj.hook(0x401100, length=5)  # Address of call to printf
+def skip_printf(state):
+    pass  # Do nothing, just skip
+
+# Hook sleep/anti-debug functions
+@proj.hook(0x401050, length=5)  # Address of call to sleep
+def skip_sleep(state):
+    pass
+
+# Replace a function with a summary
+class AlwaysSucceed(angr.SimProcedure):
+    def run(self):
+        return 1
+
+proj.hook_symbol('check_license', AlwaysSucceed())
+```
+
+### Exploring from Specific Address
+
+```python
+# Start from middle of function (skip initialization)
+state = proj.factory.blank_state(addr=0x401200)
+
+# Set up registers/memory manually
+state.regs.rdi = 0x600000  # Pointer to input buffer
+state.memory.store(0x600000, b"AAAA" + b"\x00" * 28)
+
+simgr = proj.factory.simgr(state)
+simgr.explore(find=0x401300, avoid=0x401350)
+```
+
+### Common Patterns and Tips
+
+```python
+# Pattern 1: argv-based input
+state = proj.factory.entry_state(args=['./binary', flag_sym])
+
+# Pattern 2: Multiple find/avoid addresses
+simgr.explore(
+    find=[0x401234, 0x401300],     # Any success path
+    avoid=[0x401256, 0x401400]     # All failure paths
+)
+
+# Pattern 3: Find by output string (no address needed)
+def is_successful(state):
+    stdout = state.posix.dumps(1)  # fd 1 = stdout
+    return b"Correct" in stdout
+
+def should_avoid(state):
+    stdout = state.posix.dumps(1)
+    return b"Wrong" in stdout
+
+simgr.explore(find=is_successful, avoid=should_avoid)
+
+# Pattern 4: Timeout protection
+simgr.explore(find=0x401234, avoid=0x401256, num_find=1)
+# Or use exploration techniques:
+simgr.use_technique(angr.exploration_techniques.DFS())  # Depth-first
+simgr.use_technique(angr.exploration_techniques.LengthLimiter(max_length=500))
+```
+
+### Dealing with Path Explosion
+
+```python
+# Use DFS instead of BFS (default) for flag checkers
+simgr.use_technique(angr.exploration_techniques.DFS())
+
+# Limit symbolic memory operations
+state.options.add(angr.options.ZERO_FILL_UNCONSTRAINED_MEMORY)
+state.options.add(angr.options.ZERO_FILL_UNCONSTRAINED_REGISTERS)
+
+# Hook expensive functions (crypto, hashing) to avoid explosion
+import hashlib
+class SHA256Hook(angr.SimProcedure):
+    def run(self, data, length, output):
+        # Concretize input and compute hash
+        concrete_data = self.state.solver.eval(
+            self.state.memory.load(data, self.state.solver.eval(length)),
+            cast_to=bytes
+        )
+        h = hashlib.sha256(concrete_data).digest()
+        self.state.memory.store(output, h)
+
+proj.hook_symbol('SHA256', SHA256Hook())
+```
+
+### angr CFG Recovery
+
+```python
+# Control flow graph for understanding structure
+cfg = proj.analyses.CFGFast()
+print(f"Functions found: {len(cfg.functions)}")
+
+# Find main
+for addr, func in cfg.functions.items():
+    if func.name == 'main':
+        print(f"main at {addr:#x}")
+        break
+
+# Cross-references
+node = cfg.model.get_any_node(0x401234)
+print("Predecessors:", [hex(p.addr) for p in cfg.model.get_predecessors(node)])
+```
+
+**Key insight:** angr works best on flag-checker binaries with clear success/failure paths. For complex binaries, hook expensive functions (crypto, I/O) and use DFS exploration. Start with the simplest approach (just find/avoid addresses) before adding constraints. If angr is slow, constrain input to printable ASCII and add known prefix.
+
+**When to use:** Flag validators with branching logic, maze/path-finding binaries, constraint-heavy checks, automated binary analysis. Less effective for: heavy crypto, floating-point math, complex heap operations.
+
+---
+
+## lldb (LLVM Debugger)
+
+Primary debugger for macOS/iOS. Also works on Linux. Preferred for Swift/Objective-C and Apple platform binaries.
+
+### Basic Commands
+
+```bash
+lldb ./binary
+(lldb) run                          # Run program
+(lldb) b main                       # Breakpoint on main
+(lldb) b 0x401234                   # Breakpoint at address
+(lldb) breakpoint set -r "check.*"  # Regex breakpoint
+(lldb) c                            # Continue
+(lldb) si                           # Step instruction
+(lldb) ni                           # Next instruction
+(lldb) register read                # Show all registers
+(lldb) register write rax 0         # Modify register
+(lldb) memory read 0x401000 -c 32   # Read 32 bytes
+(lldb) x/s $rsi                     # Examine string (GDB-style)
+(lldb) dis -n main                  # Disassemble function
+(lldb) image list                   # Loaded modules + base addresses
+```
+
+### Scripting (Python)
+
+```python
+# lldb Python scripting
+import lldb
+
+def hook_strcmp(debugger, command, result, internal_dict):
+    target = debugger.GetSelectedTarget()
+    process = target.GetProcess()
+    thread = process.GetSelectedThread()
+    frame = thread.GetSelectedFrame()
+    arg0 = frame.FindRegister("rdi").GetValueAsUnsigned()
+    arg1 = frame.FindRegister("rsi").GetValueAsUnsigned()
+    s0 = process.ReadCStringFromMemory(arg0, 256, lldb.SBError())
+    s1 = process.ReadCStringFromMemory(arg1, 256, lldb.SBError())
+    print(f'strcmp("{s0}", "{s1}")')
+
+# Register in lldb: command script add -f script.hook_strcmp hook_strcmp
+```
+
+**Key insight:** Use lldb for macOS binaries (Mach-O), iOS apps, and when GDB isn't available. `image list` gives ASLR slide for PIE binaries. Scripting API is more structured than GDB's.
+
+---
+
+## x64dbg (Windows Debugger)
+
+Open-source Windows debugger with modern UI. Alternative to OllyDbg/WinDbg for Windows RE challenges.
+
+### Key Features
+
+```
+# Launch
+x64dbg.exe binary.exe         # 64-bit
+x32dbg.exe binary.exe         # 32-bit
+
+# Essential shortcuts
+F2      → Toggle breakpoint
+F7      → Step into
+F8      → Step over
+F9      → Run
+Ctrl+G  → Go to address
+Ctrl+F  → Find pattern in memory
+```
+
+### Scripting
+
+```
+# x64dbg command line
+bp 0x401234                    # Breakpoint
+SetBPX 0x401234, 0, "log {s:utf8@[esp+4]}"  # Log string arg on hit
+run                            # Continue
+StepOver                       # Step over
+```
+
+### Common CTF Workflow
+
+1. Set breakpoint on `GetWindowTextA`/`MessageBoxA` for GUI crackers
+2. Trace back from success/failure message
+3. Use **Scylla** plugin for IAT reconstruction on packed binaries
+4. **Snowman** decompiler plugin for quick pseudo-C
+
+**Key insight:** x64dbg has built-in pattern scanning, hardware breakpoints, and conditional logging. For Windows CTF binaries, it's often faster than IDA/Ghidra for dynamic analysis. Use the **xAnalyzer** plugin for automatic function argument annotation.
 
 ---
 


### PR DESCRIPTION

This PR fills critical gaps in the `ctf-reverse` skill by adding 6 missing tools and language-specific techniques that are commonly needed in modern CTF reverse engineering challenges.

### New in languages.md
- **Go binary reversing** — GoReSym for symbol recovery on stripped binaries, Go memory layout (string, slice, interface, map), goroutine/channel analysis, defer mechanism, embed.FS detection, and a step-by-step workflow
- **Rust binary reversing** — Recognition markers, `rustfilt` demangling, Option/Result/Vec/String memory layout, iterator chain patterns, and panic message exploitation for quick source path leaks

### New in tools.md
- **Frida** — Runtime function hooking, anti-debug bypass (ptrace, IsDebuggerPresent, timing checks), memory scanning, function replacement, Stalker instruction tracing, r2frida integration, Android/iOS support
- **angr** — Symbolic execution for automated flag-checker solving, symbolic input with printable ASCII constraints, function hooking to avoid path explosion, DFS exploration, CFG recovery
- **lldb** — Basic commands and Python scripting for macOS/iOS binary analysis
- **x64dbg** — Windows debugger essentials for CTF crackmes

### Updated in SKILL.md
- Added quick-reference entries for all new techniques
- Updated problem-solving workflow to include Frida and angr as early steps
- Updated resource index descriptions