### PR TITLE
Add multi-platform Prerequisites and Environment Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,53 @@
 npx skills add ljagiello/ctf-skills
 ```
 
+## Environment Setup
+
+Two setup strategies depending on your workflow:
+
+### Pre-install (recommended before competitions)
+
+Run these commands once to install all commonly needed tools:
+
+**Python packages (all platforms):**
+```bash
+pip install pwntools pycryptodome z3-solver sympy gmpy2 hashpumpy \
+  angr frida-tools qiling requests flask-unsign sqlmap \
+  ropper ROPgadget volatility3 yara-python pefile capstone \
+  oletools unicorn scapy Pillow numpy matplotlib shodan \
+  uncompyle6 lief dnspython dnslib dissect.cobaltstrike
+```
+
+**Linux (apt):**
+```bash
+apt install gdb radare2 binutils binwalk foremost libimage-exiftool-perl \
+  tshark sleuthkit ffmpeg steghide testdisk john pcapfix \
+  nmap whois dnsutils hashcat strace ltrace imagemagick curl jq \
+  apktool upx qemu-system-x86 sagemath qrencode
+```
+
+**macOS (Homebrew):**
+```bash
+brew install gdb radare2 binutils binwalk exiftool wireshark sleuthkit \
+  ffmpeg steghide testdisk john-jumbo nmap whois bind hashcat \
+  imagemagick curl jq apktool upx qemu sagemath qrencode
+```
+
+**Ruby gems (all platforms):**
+```bash
+gem install one_gadget seccomp-tools zsteg
+```
+
+**Manual install:**
+- Ghidra — [ghidra-sre.org](https://ghidra-sre.org), requires Java 17+
+- pwndbg — [github.com/pwndbg/pwndbg](https://github.com/pwndbg/pwndbg)
+- RsaCtfTool — `git clone https://github.com/RsaCtfTool/RsaCtfTool`
+- dnSpy — [github.com/dnSpy/dnSpy](https://github.com/dnSpy/dnSpy) (.NET decompiler, Windows)
+
+### On-demand (during challenges)
+
+Each skill's `SKILL.md` has a **Prerequisites** section listing only the tools needed for that category. Install as you go when the agent encounters a missing tool.
+
 ## Skills
 
 | Skill | Files | Description |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Run these commands once to install all commonly needed tools:
 
 **Python packages (all platforms):**
 ```bash
-pip install pwntools pycryptodome z3-solver sympy gmpy2 hashpumpy \
+pip install pwntools pycryptodome z3-solver sympy gmpy2 hashpumpy fpylll py_ecc \
   angr frida-tools qiling requests flask-unsign sqlmap \
   ropper ROPgadget volatility3 yara-python pefile capstone \
   oletools unicorn scapy Pillow numpy matplotlib shodan \
@@ -36,8 +36,8 @@ apt install gdb radare2 binutils binwalk foremost libimage-exiftool-perl \
 **macOS (Homebrew):**
 ```bash
 brew install gdb radare2 binutils binwalk exiftool wireshark sleuthkit \
-  ffmpeg steghide testdisk john-jumbo nmap whois bind hashcat \
-  imagemagick curl jq apktool upx qemu sagemath qrencode
+  ffmpeg testdisk john-jumbo nmap whois bind hashcat ghidra \
+  imagemagick curl jq apktool upx qemu qrencode
 ```
 
 **Ruby gems (all platforms):**
@@ -45,10 +45,16 @@ brew install gdb radare2 binutils binwalk exiftool wireshark sleuthkit \
 gem install one_gadget seccomp-tools zsteg
 ```
 
+**Go tools (all platforms, requires Go):**
+```bash
+go install github.com/ffuf/ffuf/v2@latest
+```
+
 **Manual install:**
-- Ghidra — [ghidra-sre.org](https://ghidra-sre.org), requires Java 17+
-- pwndbg — [github.com/pwndbg/pwndbg](https://github.com/pwndbg/pwndbg)
+- pwndbg — Linux: [github.com/pwndbg/pwndbg](https://github.com/pwndbg/pwndbg), macOS: `brew install pwndbg/tap/pwndbg-gdb`
 - RsaCtfTool — `git clone https://github.com/RsaCtfTool/RsaCtfTool`
+- SageMath — Linux: `apt install sagemath`, macOS: `brew install --cask sage`
+- steghide — Linux: `apt install steghide` (not available via Homebrew)
 - dnSpy — [github.com/dnSpy/dnSpy](https://github.com/dnSpy/dnSpy) (.NET decompiler, Windows)
 
 ### On-demand (during challenges)

--- a/ctf-crypto/SKILL.md
+++ b/ctf-crypto/SKILL.md
@@ -16,7 +16,7 @@ Quick reference for crypto CTF challenges. Each technique has a one-liner here; 
 
 **Python packages (all platforms):**
 ```bash
-pip install pycryptodome z3-solver sympy gmpy2 hashpumpy
+pip install pycryptodome z3-solver sympy gmpy2 hashpumpy fpylll py_ecc
 ```
 
 **Linux (apt):**
@@ -26,10 +26,11 @@ apt install hashcat sagemath
 
 **macOS (Homebrew):**
 ```bash
-brew install hashcat sagemath
+brew install hashcat
 ```
 
 **Manual install:**
+- SageMath — Linux: `apt install sagemath`, macOS: `brew install --cask sage`
 - RsaCtfTool — `git clone https://github.com/RsaCtfTool/RsaCtfTool` (automated RSA attacks)
 
 > **Note:** `gmpy2` requires libgmp — Linux: `apt install libgmp-dev`, macOS: `brew install gmp`.

--- a/ctf-crypto/SKILL.md
+++ b/ctf-crypto/SKILL.md
@@ -12,6 +12,28 @@ metadata:
 
 Quick reference for crypto CTF challenges. Each technique has a one-liner here; see supporting files for full details with code.
 
+## Prerequisites
+
+**Python packages (all platforms):**
+```bash
+pip install pycryptodome z3-solver sympy gmpy2 hashpumpy
+```
+
+**Linux (apt):**
+```bash
+apt install hashcat sagemath
+```
+
+**macOS (Homebrew):**
+```bash
+brew install hashcat sagemath
+```
+
+**Manual install:**
+- RsaCtfTool — `git clone https://github.com/RsaCtfTool/RsaCtfTool` (automated RSA attacks)
+
+> **Note:** `gmpy2` requires libgmp — Linux: `apt install libgmp-dev`, macOS: `brew install gmp`.
+
 ## Additional Resources
 
 - [classic-ciphers.md](classic-ciphers.md) - Classic ciphers: Vigenere (+ Kasiski examination), Atbash, substitution wheels, XOR variants (+ multi-byte frequency analysis), deterministic OTP, cascade XOR, book cipher, OTP key reuse / many-time pad, variable-length homophonic substitution, grid permutation cipher keyspace reduction, image-based Caesar shift ciphers, XOR key recovery via file format headers

--- a/ctf-forensics/SKILL.md
+++ b/ctf-forensics/SKILL.md
@@ -12,6 +12,30 @@ metadata:
 
 Quick reference for forensics CTF challenges. Each technique has a one-liner here; see supporting files for full details.
 
+## Prerequisites
+
+**Python packages (all platforms):**
+```bash
+pip install volatility3 Pillow numpy matplotlib
+```
+
+**Linux (apt):**
+```bash
+apt install binwalk foremost libimage-exiftool-perl tshark sleuthkit \
+  ffmpeg steghide testdisk john pcapfix
+```
+
+**macOS (Homebrew):**
+```bash
+brew install binwalk exiftool wireshark sleuthkit ffmpeg steghide \
+  testdisk john-jumbo
+```
+
+**Ruby gems (all platforms):**
+```bash
+gem install zsteg
+```
+
 ## Additional Resources
 
 - [3d-printing.md](3d-printing.md) - 3D printing forensics (PrusaSlicer binary G-code, QOIF, heatshrink)

--- a/ctf-forensics/SKILL.md
+++ b/ctf-forensics/SKILL.md
@@ -27,7 +27,7 @@ apt install binwalk foremost libimage-exiftool-perl tshark sleuthkit \
 
 **macOS (Homebrew):**
 ```bash
-brew install binwalk exiftool wireshark sleuthkit ffmpeg steghide \
+brew install binwalk exiftool wireshark sleuthkit ffmpeg \
   testdisk john-jumbo
 ```
 

--- a/ctf-malware/SKILL.md
+++ b/ctf-malware/SKILL.md
@@ -27,12 +27,11 @@ apt install strace ltrace tshark binwalk binutils
 
 **macOS (Homebrew):**
 ```bash
-brew install wireshark binwalk binutils
+brew install wireshark binwalk binutils ghidra
 ```
 
 **Manual install:**
 - dnSpy — [GitHub](https://github.com/dnSpy/dnSpy), .NET decompiler (Windows)
-- Ghidra — [ghidra-sre.org](https://ghidra-sre.org), requires Java 17+
 
 ## Additional Resources
 

--- a/ctf-malware/SKILL.md
+++ b/ctf-malware/SKILL.md
@@ -12,6 +12,28 @@ metadata:
 
 Quick reference for malware analysis CTF challenges. Each technique has a one-liner here; see supporting files for full details with code.
 
+## Prerequisites
+
+**Python packages (all platforms):**
+```bash
+pip install yara-python pefile capstone oletools unicorn pycryptodome \
+  volatility3 dissect.cobaltstrike
+```
+
+**Linux (apt):**
+```bash
+apt install strace ltrace tshark binwalk binutils
+```
+
+**macOS (Homebrew):**
+```bash
+brew install wireshark binwalk binutils
+```
+
+**Manual install:**
+- dnSpy — [GitHub](https://github.com/dnSpy/dnSpy), .NET decompiler (Windows)
+- Ghidra — [ghidra-sre.org](https://ghidra-sre.org), requires Java 17+
+
 ## Additional Resources
 
 - [scripts-and-obfuscation.md](scripts-and-obfuscation.md) - JavaScript deobfuscation, PowerShell analysis, eval/base64 decoding, junk code detection, hex payloads, Debian package analysis, dynamic analysis techniques (strace/ltrace, network monitoring, memory string extraction, automated sandbox execution), YARA rules for malware detection, shellcode analysis (Unicorn Engine, Capstone), memory forensics for malware (Volatility 3 malfind, process injection detection), anti-analysis techniques (VM detection, timing evasion, API hashing, process injection)

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -16,7 +16,7 @@ Quick reference for miscellaneous CTF challenges. Each technique has a one-liner
 
 **Python packages (all platforms):**
 ```bash
-pip install z3-solver pwntools scapy Pillow numpy requests dnslib
+pip install z3-solver pwntools Pillow numpy requests dnslib
 ```
 
 **Linux (apt):**
@@ -26,8 +26,11 @@ apt install ffmpeg qrencode sagemath
 
 **macOS (Homebrew):**
 ```bash
-brew install ffmpeg qrencode sagemath
+brew install ffmpeg qrencode
 ```
+
+**Manual install:**
+- SageMath — Linux: `apt install sagemath`, macOS: `brew install --cask sage`
 
 ## Additional Resources
 

--- a/ctf-misc/SKILL.md
+++ b/ctf-misc/SKILL.md
@@ -12,6 +12,23 @@ metadata:
 
 Quick reference for miscellaneous CTF challenges. Each technique has a one-liner here; see supporting files for full details.
 
+## Prerequisites
+
+**Python packages (all platforms):**
+```bash
+pip install z3-solver pwntools scapy Pillow numpy requests dnslib
+```
+
+**Linux (apt):**
+```bash
+apt install ffmpeg qrencode sagemath
+```
+
+**macOS (Homebrew):**
+```bash
+brew install ffmpeg qrencode sagemath
+```
+
 ## Additional Resources
 
 - [pyjails.md](pyjails.md) - Python jail/sandbox escape techniques, quine context detection, restricted character repunit decomposition, func_globals module chain traversal, restricted charset number generation, class attribute persistence

--- a/ctf-osint/SKILL.md
+++ b/ctf-osint/SKILL.md
@@ -16,7 +16,7 @@ Quick reference for OSINT CTF challenges. Each technique has a one-liner here; s
 
 **Python packages (all platforms):**
 ```bash
-pip install shodan requests dnspython Pillow
+pip install shodan Pillow
 ```
 
 **Linux (apt):**

--- a/ctf-osint/SKILL.md
+++ b/ctf-osint/SKILL.md
@@ -12,6 +12,23 @@ metadata:
 
 Quick reference for OSINT CTF challenges. Each technique has a one-liner here; see supporting files for full details.
 
+## Prerequisites
+
+**Python packages (all platforms):**
+```bash
+pip install shodan requests dnspython Pillow
+```
+
+**Linux (apt):**
+```bash
+apt install whois dnsutils nmap libimage-exiftool-perl imagemagick curl
+```
+
+**macOS (Homebrew):**
+```bash
+brew install whois bind nmap exiftool imagemagick curl
+```
+
 ## Additional Resources
 
 - [social-media.md](social-media.md) - Twitter/X (user IDs, Snowflake timestamps, Nitter, memory.lol, Wayback CDX), Tumblr (blog checks, post JSON, avatars), BlueSky search + API, Unicode homoglyph steganography, Discord API, username OSINT (namechk, whatsmyname, Osint Industries), username metadata mining (postal codes), platform false positives, multi-platform chains, Strava fitness route OSINT

--- a/ctf-pwn/SKILL.md
+++ b/ctf-pwn/SKILL.md
@@ -12,6 +12,32 @@ metadata:
 
 Quick reference for binary exploitation (pwn) CTF challenges. Each technique has a one-liner here; see supporting files for full details.
 
+## Prerequisites
+
+**Python packages (all platforms):**
+```bash
+pip install pwntools ropper ROPgadget
+```
+
+**Linux (apt):**
+```bash
+apt install gdb binutils strace ltrace qemu-system-x86
+```
+
+**macOS (Homebrew):**
+```bash
+brew install gdb binutils qemu
+```
+
+**Ruby gems (all platforms):**
+```bash
+gem install one_gadget seccomp-tools
+```
+
+**Manual install:**
+- pwndbg — [GitHub](https://github.com/pwndbg/pwndbg), GDB plugin for exploit development
+- checksec — included with pwntools
+
 ## Additional Resources
 
 - [overflow-basics.md](overflow-basics.md) - Stack/global buffer overflow, ret2win, canary bypass, canary byte-by-byte brute force on forking servers, struct pointer overwrite, signed integer bypass, hidden gadgets, stride-based OOB read leak, parser stack overflow via unchecked memcpy length with callee-saved register restoration

--- a/ctf-pwn/SKILL.md
+++ b/ctf-pwn/SKILL.md
@@ -35,7 +35,7 @@ gem install one_gadget seccomp-tools
 ```
 
 **Manual install:**
-- pwndbg — [GitHub](https://github.com/pwndbg/pwndbg), GDB plugin for exploit development
+- pwndbg — Linux: [GitHub](https://github.com/pwndbg/pwndbg), macOS: `brew install pwndbg/tap/pwndbg-gdb`
 - checksec — included with pwntools
 
 ## Additional Resources

--- a/ctf-pwn/sandbox-escape.md
+++ b/ctf-pwn/sandbox-escape.md
@@ -14,7 +14,7 @@
 
 ## Python Sandbox Escape
 
-Python jail/sandbox escape techniques (AST bypass, audit hook bypass, MRO-based builtin recovery, decorator chains, restricted charset tricks, and more) are covered comprehensively in [ctf-misc/pyjails.md](../ctf-misc/pyjails.md).
+Python jail/sandbox escape techniques (AST bypass, audit hook bypass, MRO-based builtin recovery, decorator chains, restricted charset tricks, and more) are covered comprehensively in the `ctf-misc` skill — invoke `/ctf-misc` for pyjail techniques.
 
 ## VM Exploitation (Custom Bytecode)
 

--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -26,12 +26,11 @@ apt install gdb radare2 binutils strace ltrace apktool upx
 
 **macOS (Homebrew):**
 ```bash
-brew install gdb radare2 binutils apktool upx
+brew install gdb radare2 binutils apktool upx ghidra
 ```
 
 **Manual install:**
-- Ghidra — [ghidra-sre.org](https://ghidra-sre.org), requires Java 17+
-- pwndbg — [GitHub](https://github.com/pwndbg/pwndbg), GDB plugin
+- pwndbg — Linux: [GitHub](https://github.com/pwndbg/pwndbg), macOS: `brew install pwndbg/tap/pwndbg-gdb`
 
 ## Additional Resources
 

--- a/ctf-reverse/SKILL.md
+++ b/ctf-reverse/SKILL.md
@@ -12,6 +12,27 @@ metadata:
 
 Quick reference for RE challenges. For detailed techniques, see supporting files.
 
+## Prerequisites
+
+**Python packages (all platforms):**
+```bash
+pip install frida-tools angr qiling uncompyle6 capstone lief z3-solver
+```
+
+**Linux (apt):**
+```bash
+apt install gdb radare2 binutils strace ltrace apktool upx
+```
+
+**macOS (Homebrew):**
+```bash
+brew install gdb radare2 binutils apktool upx
+```
+
+**Manual install:**
+- Ghidra — [ghidra-sre.org](https://ghidra-sre.org), requires Java 17+
+- pwndbg — [GitHub](https://github.com/pwndbg/pwndbg), GDB plugin
+
 ## Additional Resources
 
 - [tools.md](tools.md) - Static analysis tools (GDB, Ghidra, radare2, IDA, Binary Ninja, dogbolt.org, RISC-V with Capstone, Unicorn emulation, Python bytecode, WASM, Android APK, .NET, packed binaries)

--- a/ctf-web/SKILL.md
+++ b/ctf-web/SKILL.md
@@ -16,7 +16,7 @@ Quick reference for web CTF challenges. Each technique has a one-liner here; see
 
 **Python packages (all platforms):**
 ```bash
-pip install sqlmap flask-unsign requests pycryptodome
+pip install sqlmap flask-unsign requests
 ```
 
 **Linux (apt):**
@@ -32,7 +32,6 @@ brew install hashcat jq curl
 **Go tools (all platforms, requires Go):**
 ```bash
 go install github.com/ffuf/ffuf/v2@latest
-go install github.com/hahwul/dalfox/v2@latest
 ```
 
 **Manual install:**
@@ -317,7 +316,6 @@ sqlmap -u "http://target/?id=1" --dbs       # SQLi
 ffuf -u http://target/FUZZ -w wordlist.txt   # Directory fuzzing
 flask-unsign --decode --cookie "eyJ..."      # JWT decode
 hashcat -m 16500 jwt.txt wordlist.txt        # JWT crack
-dalfox url http://target/?q=test             # XSS
 ```
 
 ## Flask/Werkzeug Debug Mode

--- a/ctf-web/SKILL.md
+++ b/ctf-web/SKILL.md
@@ -12,6 +12,32 @@ metadata:
 
 Quick reference for web CTF challenges. Each technique has a one-liner here; see supporting files for full details with payloads and code.
 
+## Prerequisites
+
+**Python packages (all platforms):**
+```bash
+pip install sqlmap flask-unsign requests pycryptodome
+```
+
+**Linux (apt):**
+```bash
+apt install hashcat jq curl
+```
+
+**macOS (Homebrew):**
+```bash
+brew install hashcat jq curl
+```
+
+**Go tools (all platforms, requires Go):**
+```bash
+go install github.com/ffuf/ffuf/v2@latest
+go install github.com/hahwul/dalfox/v2@latest
+```
+
+**Manual install:**
+- ysoserial — [GitHub](https://github.com/frohoff/ysoserial), requires Java (Java deserialization payloads)
+
 ## Additional Resources
 
 - [server-side.md](server-side.md) - Core server-side injection attacks: SQLi (EXIF metadata injection, MySQL column truncation, backslash/hex bypass, second-order, LIKE brute-force, processList trick, XML entity WAF bypass, Shift-JIS encoding bypass), SSTI (Jinja2, Go, EJS, ERB Sequel bypass, Mako, Twig, `__dict__.update()` quote bypass), SSRF (Host header, DNS rebinding, curl redirect), XXE, XML injection via X-Forwarded-For header, command injection (newline, blocklist bypass, sendmail, multi-barcode, git CLI newline injection), PHP type juggling, PHP file inclusion / php://filter

--- a/solve-challenge/SKILL.md
+++ b/solve-challenge/SKILL.md
@@ -21,7 +21,7 @@ Two setup strategies depending on your workflow:
 
 **Python packages (all platforms):**
 ```bash
-pip install pwntools pycryptodome z3-solver sympy gmpy2 hashpumpy \
+pip install pwntools pycryptodome z3-solver sympy gmpy2 hashpumpy fpylll py_ecc \
   angr frida-tools qiling requests flask-unsign sqlmap \
   ropper ROPgadget volatility3 yara-python pefile capstone \
   oletools unicorn scapy Pillow numpy matplotlib shodan \
@@ -39,8 +39,8 @@ apt install gdb radare2 binutils binwalk foremost libimage-exiftool-perl \
 **macOS (Homebrew):**
 ```bash
 brew install gdb radare2 binutils binwalk exiftool wireshark sleuthkit \
-  ffmpeg steghide testdisk john-jumbo nmap whois bind hashcat \
-  imagemagick curl jq apktool upx qemu sagemath qrencode
+  ffmpeg testdisk john-jumbo nmap whois bind hashcat ghidra \
+  imagemagick curl jq apktool upx qemu qrencode
 ```
 
 **Ruby gems (all platforms):**
@@ -48,10 +48,17 @@ brew install gdb radare2 binutils binwalk exiftool wireshark sleuthkit \
 gem install one_gadget seccomp-tools zsteg
 ```
 
+**Go tools (all platforms, requires Go):**
+```bash
+go install github.com/ffuf/ffuf/v2@latest
+```
+
 **Manual install:**
-- Ghidra — [ghidra-sre.org](https://ghidra-sre.org), requires Java 17+
-- pwndbg — [github.com/pwndbg/pwndbg](https://github.com/pwndbg/pwndbg)
+- pwndbg — Linux: [github.com/pwndbg/pwndbg](https://github.com/pwndbg/pwndbg), macOS: `brew install pwndbg/tap/pwndbg-gdb`
 - RsaCtfTool — `git clone https://github.com/RsaCtfTool/RsaCtfTool`
+- SageMath — Linux: `apt install sagemath`, macOS: `brew install --cask sage`
+- steghide — Linux: `apt install steghide` (not available via Homebrew)
+- dnSpy — [github.com/dnSpy/dnSpy](https://github.com/dnSpy/dnSpy) (.NET decompiler, Windows)
 
 ### On-demand (during challenges)
 

--- a/solve-challenge/SKILL.md
+++ b/solve-challenge/SKILL.md
@@ -13,6 +13,50 @@ metadata:
 
 You're a skilled CTF player. Your goal is to solve the challenge and find the flag.
 
+## Environment Setup
+
+Two setup strategies depending on your workflow:
+
+### Pre-install (recommended before competitions)
+
+**Python packages (all platforms):**
+```bash
+pip install pwntools pycryptodome z3-solver sympy gmpy2 hashpumpy \
+  angr frida-tools qiling requests flask-unsign sqlmap \
+  ropper ROPgadget volatility3 yara-python pefile capstone \
+  oletools unicorn scapy Pillow numpy matplotlib shodan \
+  uncompyle6 lief dnspython dnslib dissect.cobaltstrike
+```
+
+**Linux (apt):**
+```bash
+apt install gdb radare2 binutils binwalk foremost libimage-exiftool-perl \
+  tshark sleuthkit ffmpeg steghide testdisk john pcapfix \
+  nmap whois dnsutils hashcat strace ltrace imagemagick curl jq \
+  apktool upx qemu-system-x86 sagemath qrencode
+```
+
+**macOS (Homebrew):**
+```bash
+brew install gdb radare2 binutils binwalk exiftool wireshark sleuthkit \
+  ffmpeg steghide testdisk john-jumbo nmap whois bind hashcat \
+  imagemagick curl jq apktool upx qemu sagemath qrencode
+```
+
+**Ruby gems (all platforms):**
+```bash
+gem install one_gadget seccomp-tools zsteg
+```
+
+**Manual install:**
+- Ghidra — [ghidra-sre.org](https://ghidra-sre.org), requires Java 17+
+- pwndbg — [github.com/pwndbg/pwndbg](https://github.com/pwndbg/pwndbg)
+- RsaCtfTool — `git clone https://github.com/RsaCtfTool/RsaCtfTool`
+
+### On-demand (during challenges)
+
+Each category skill's `SKILL.md` has a **Prerequisites** section listing only the tools needed for that category. Install as you go.
+
 ## Workflow
 
 ### Step 1: Recon


### PR DESCRIPTION
## Summary

- Add **Prerequisites** section to all 8 category `SKILL.md` files with platform-specific install commands (pip, apt, brew, gem, go, manual download)
- Add **Environment Setup** section to `README.md` and `solve-challenge/SKILL.md` with two strategies:
  - **Pre-install**: one-shot commands to install all tools before a competition
  - **On-demand**: per-skill Prerequisites for installing tools as needed

## Changes

- Tools were audited against actual usage across all 90 supporting `.md` files
- Each Prerequisites section covers: Python packages (all platforms), Linux (apt), macOS (Homebrew), Ruby gems, Go tools, and manual installs where applicable
- New tools added that were previously undocumented: hashpumpy, lief, capstone, z3-solver, numpy, matplotlib, steghide, zsteg, testdisk, john, pcapfix, dnspython, dnslib, dissect.cobaltstrike, unicorn, qrencode, imagemagick, and more

## Test plan

- [x] Verify each `SKILL.md` renders correctly on GitHub
- [x] Spot-check install commands on Linux and macOS
- [x] Confirm no duplicate tools in centralized Pre-install blocks