### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## About This Repository
+
+This repository contains offensive security techniques documented for **authorized CTF (Capture The Flag) competitions, security research, and education**. The techniques described — including exploitation, injection, cryptographic attacks, and reverse engineering — are intentionally offensive in nature. That is the purpose of the project.
+
+## Reporting Security Issues
+
+Please report the following via [GitHub Security Advisories](https://github.com/ljagiello/ctf-skills/security/advisories/new):
+
+- **Leaked credentials or PII** — Real API keys, passwords, tokens, or personally identifiable information accidentally included from writeup sources
+- **Malicious links** — URLs pointing to live malicious infrastructure rather than CTF challenge servers
+- **Payloads targeting real infrastructure** — Examples that reference production systems, real IP addresses, or non-example domains (outside of `example.com`, `attacker.com`, etc.)
+
+## What Is NOT a Security Issue
+
+- Techniques describing how to exploit vulnerabilities — that is the intended content
+- Code snippets that perform offensive operations (shellcode, ROP chains, injection payloads, etc.)
+- References to real CVEs or public security advisories
+- Links to published CTF writeups, tools, or documentation
+
+## Responsible Use
+
+Users of these materials are expected to apply them only in:
+
+- CTF competitions
+- Authorized penetration testing engagements
+- Security research with proper authorization
+- Educational and training environments
+
+Misuse of these techniques against systems without authorization is illegal and unethical.


### PR DESCRIPTION
## Summary
- Adds a security policy tailored for a CTF technique repository
- Defines what constitutes a reportable issue (leaked credentials, malicious links, payloads targeting real infrastructure)
- Clarifies that offensive technique documentation is intentional, not a vulnerability
- Includes responsible use expectations

## Test plan
- [x] Verify SECURITY.md renders correctly on GitHub
- [x] Verify GitHub Security Advisories link is correct