### PR TITLE
Add CONTRIBUTING.md, issue templates, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: Report a bug in a skill, script, or tooling
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill in the details below to help us investigate.
+
+  - type: input
+    id: affected-file
+    attributes:
+      label: Affected File or Skill
+      description: Which file or skill category is affected?
+      placeholder: "e.g., ctf-web/SKILL.md, scripts/install_ctf_tools.sh"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the bug? Be as specific as possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Any relevant environment details (OS, tool versions, agent runtime)
+      placeholder: |
+        - OS: Ubuntu 24.04
+        - Python: 3.14
+        - Agent: Claude Code
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Issues
+    url: https://github.com/ljagiello/ctf-skills/security/advisories/new
+    about: >
+      Report leaked credentials, malicious links, or payloads targeting real infrastructure
+      via GitHub Security Advisories. Do NOT use regular issues for security reports.

--- a/.github/ISSUE_TEMPLATE/coverage-gap.yml
+++ b/.github/ISSUE_TEMPLATE/coverage-gap.yml
@@ -1,0 +1,42 @@
+name: Coverage Gap
+description: Report missing technique coverage in a skill category
+labels: ["coverage-gap"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to flag areas where a skill category is missing techniques that would help solve real CTF challenges.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Which skill category has the coverage gap?
+      options:
+        - ctf-ai-ml
+        - ctf-crypto
+        - ctf-forensics
+        - ctf-malware
+        - ctf-misc
+        - ctf-osint
+        - ctf-pwn
+        - ctf-reverse
+        - ctf-web
+    validations:
+      required: true
+
+  - type: textarea
+    id: whats-missing
+    attributes:
+      label: What's Missing
+      description: Describe the techniques, vulnerability classes, or tool coverage that is absent or insufficient
+    validations:
+      required: true
+
+  - type: textarea
+    id: reference-links
+    attributes:
+      label: Reference Links
+      description: Links to writeups, papers, tools, or documentation that demonstrate the gap
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new-technique.yml
+++ b/.github/ISSUE_TEMPLATE/new-technique.yml
@@ -1,0 +1,52 @@
+name: New Technique
+description: Suggest a new CTF technique to add from a writeup or competition
+labels: ["new-technique"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing a new technique! Please provide the details below.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Which skill category does this technique belong to?
+      options:
+        - ctf-ai-ml
+        - ctf-crypto
+        - ctf-forensics
+        - ctf-malware
+        - ctf-misc
+        - ctf-osint
+        - ctf-pwn
+        - ctf-reverse
+        - ctf-web
+        - New category (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: source-url
+    attributes:
+      label: Source Writeup URL
+      description: Link to the CTF writeup, blog post, or competition solution
+      placeholder: "https://example.com/ctf-writeup"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Technique Description
+      description: Brief description of the technique, what it exploits, and when an agent should use it
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other relevant details (related CVEs, alternative writeups, edge cases)
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What changed and why? 1-3 sentences. -->
+
+## Category
+
+<!-- Which skills or areas of the repo are affected? -->
+
+-
+
+## Source
+
+<!-- If adding techniques from writeups, link them here. Remove if not applicable. -->
+
+-
+
+## Checklist
+
+- [ ] `pytest` tests pass (`python -m pytest tests/ -v`)
+- [ ] Security audit is clean (`python3 scripts/skill_security_auditor.py <skill-dir> --strict`) <!-- e.g., ctf-web -->
+- [ ] Markdown lint is clean (`markdownlint-cli2`)
+- [ ] Pre-commit hooks ran successfully (`pre-commit run --all-files`)
+- [ ] No leaked credentials, real IPs, or non-example domains in content

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -6,6 +6,7 @@ exclude = [
   "quipqiup\\.com",       # Frequent timeouts
   "rbndr\\.us",           # DNS rebinding tool — often offline
   "whatsmyname\\.app",    # Blocks automated requests (403)
+  "dcode\\.fr",           # Frequent timeouts in CI
 ]
 
 # Accept common "soft error" status codes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,164 @@
+# Contributing to ctf-skills
+
+Thanks for helping expand the CTF skills collection. This guide covers how to set up your environment, add techniques, create new skill categories, and get your PR merged.
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.12+
+- Node.js (for markdownlint)
+- [pre-commit](https://pre-commit.com/)
+
+### Install pre-commit hooks
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+This installs hooks that run automatically on every commit:
+
+- **trailing-whitespace** and **end-of-file-fixer** — basic formatting
+- **check-yaml** — validates YAML files
+- **check-added-large-files** — prevents accidental binary commits
+- **ruff** — Python linter and formatter (for files in `scripts/`)
+- **shellcheck** — static analysis for shell scripts
+- **markdownlint-cli2** — Markdown linter (all `.md` files)
+
+### Install test dependencies
+
+```bash
+pip install pytest
+```
+
+## Adding Techniques to an Existing Skill
+
+This is the most common contribution. Each skill category (e.g., `ctf-web`, `ctf-crypto`) has a `SKILL.md` and one or more supporting technique files.
+
+### 1. Choose the right file
+
+Look at the existing technique files in the skill directory. For example, `ctf-web/` has files like `sql-injection.md`, `server-side.md`, `client-side.md`, etc. Add your technique to the file that best matches its topic. If no file fits, you can create a new one.
+
+### 2. Follow the technique format
+
+Technique files use this structure:
+
+````markdown
+## Technique Name (Optional CTF/Year Attribution)
+
+Brief description of when and why to use this technique.
+
+```language
+# Working payload or code example
+# Use realistic but safe placeholder targets (example.com, attacker.com)
+```
+
+**Key insight:** One or two sentences explaining the core idea.
+````
+
+Conventions:
+
+- Start each technique with an h2 (`##`) heading
+- Include working code examples in fenced code blocks with a language tag
+- Use placeholder hostnames (`example.com`, `attacker.com`) — never real infrastructure
+- Attribute the source CTF/competition in the heading when known
+- Keep explanations concise — this is a quick reference, not a tutorial
+
+### 3. Update the SKILL.md
+
+After adding a technique, update the parent `SKILL.md`:
+
+- Add the technique to the **Additional Resources** list if you modified an existing file
+- If you created a new technique file, add a new entry to the list with a relative link
+
+### 4. Update the README table
+
+Update the skill's row in `README.md`: increment the **Files** count if you added a new file, and add the technique name to the **Description** column.
+
+## Creating a New Skill Category
+
+A new skill category is a directory at the repo root containing at minimum a `SKILL.md` file.
+
+The `SKILL.md` must have YAML frontmatter with these required fields:
+
+```yaml
+---
+name: ctf-newcategory
+description: >-
+  Provides [category] techniques for CTF challenges. Use when [trigger conditions].
+license: MIT
+compatibility: Requires filesystem-based agent (Claude Code or similar) with bash, Python 3, and internet access for tool installation.
+allowed-tools: Bash Read Write Edit Glob Grep Task WebFetch WebSearch
+metadata:
+  user-invocable: "false"
+---
+```
+
+Frontmatter rules enforced by tests:
+
+| Field | Requirement |
+|-------|-------------|
+| `name` | Must exactly match the directory name |
+| `description` | Must be longer than 20 characters; must start with a third-person verb (e.g., "Provides...", "Solves...") |
+| `license` | Must be `MIT` |
+| `compatibility` | Required, free-form string |
+| `allowed-tools` | Space-separated list; valid values: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `Task`, `WebFetch`, `WebSearch`, `Skill` |
+| `metadata.user-invocable` | Must be `"true"` or `"false"` |
+| `metadata.argument-hint` | Required if `user-invocable` is `"true"` |
+
+## Running Tests Locally
+
+```bash
+# Run all tests
+python -m pytest tests/ -v
+
+# Run just the frontmatter validation
+python -m pytest tests/test_skill_frontmatter.py -v
+
+# Run the security auditor on a specific skill
+python3 scripts/skill_security_auditor.py ctf-web --strict --json
+```
+
+### Running pre-commit checks manually
+
+```bash
+pre-commit run --all-files
+```
+
+## Code Quality Standards
+
+- **Markdown** — Linted by markdownlint-cli2 (relaxed rules in `.markdownlint-cli2.yaml` for CTF content)
+- **Python/Shell** — `scripts/` checked by ruff and shellcheck
+- **Security** — Every PR triggers the Skill Security Audit workflow. Critical findings fail the build. Use `<!-- audit-ok -->` to suppress intentional attack documentation.
+- **Links** — The Link Checker (lychee) validates all URLs on every PR and weekly
+
+## Pull Request Process
+
+### Before submitting
+
+1. Run `pre-commit run --all-files` and fix any issues
+2. Run `python -m pytest tests/ -v` and ensure all tests pass
+3. If you added a new skill, verify `name` in frontmatter matches the directory name
+
+### What reviewers look for
+
+- Working code examples with placeholder hostnames (no real credentials or live infrastructure)
+- Correct categorization in the right skill and file
+- Frontmatter validity and security audit passing
+- SKILL.md and README updated to reflect changes
+- Source CTF/competition attributed in technique headings when known
+
+### CI checks that must pass
+
+| Workflow | What it does |
+|----------|--------------|
+| **Tests** | Runs `pytest` on `tests/` |
+| **Markdown Lint** | Runs markdownlint-cli2 on all `.md` files |
+| **Skill Security Audit** | Scans changed skills for dangerous patterns |
+| **Link Checker** | Validates all URLs in `.md` files |
+| **Lint Scripts** | Runs ruff and shellcheck on `scripts/` |
+
+## Responsible Use
+
+This repository documents offensive security techniques for **authorized CTF competitions, security research, and education only**. All contributors must adhere to the responsible use policy in [SECURITY.md](SECURITY.md). Never include real credentials, PII, or links to live malicious infrastructure.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Skills are loaded automatically based on context. You can also invoke the orches
 /solve-challenge <challenge description or URL>
 ```
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and contribution guidelines.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds community governance files to standardize contributions and improve the new-contributor experience:
- **CONTRIBUTING.md** — dev setup, technique format spec, frontmatter schema table, CI checks, PR process, responsible use
- **3 issue templates** (YAML forms) — new-technique, bug-report, coverage-gap
- **Issue config** — disables blank issues, routes security reports to GitHub Security Advisories
- **PR template** — summary, category, source links, CI checklist
- **README** — added Contributing section linking to CONTRIBUTING.md

## Test plan

- [ ] Verify CONTRIBUTING.md renders correctly on GitHub (especially the 4-backtick nested code block)
- [ ] Verify issue templates appear at `/issues/new/choose` with correct forms and dropdowns
- [ ] Verify blank issues are disabled and security advisory link appears
- [ ] Verify PR template auto-populates when creating a new PR
- [ ] Confirm markdown lint passes on new `.md` files