### PR TITLE
fix: prevent untrusted code execution in privileged workflow

### DIFF
--- a/.github/workflows/skill-security-audit-comment.yml
+++ b/.github/workflows/skill-security-audit-comment.yml
@@ -1,0 +1,101 @@
+---
+name: Post Security Audit Comment
+
+'on':
+  workflow_run:
+    workflows: ["Skill Security Audit"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: Post audit results
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download audit report artifact
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            const match = artifacts.data.artifacts.find(a => a.name === 'security-audit-report');
+            if (!match) {
+              core.setFailed('No security-audit-report artifact found');
+              return;
+            }
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: match.id,
+              archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{ runner.temp }}/report.zip', Buffer.from(download.data));
+
+      - name: Extract artifact
+        run: |
+          mkdir -p "${{ runner.temp }}/report"
+          unzip -o "${{ runner.temp }}/report.zip" -d "${{ runner.temp }}/report"
+
+      - name: Post or update PR comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const reportDir = '${{ runner.temp }}/report';
+
+            // Read PR number
+            const prNumberFile = fs.readdirSync(reportDir).find(f => f === 'pr_number')
+              ? path.join(reportDir, 'pr_number')
+              : null;
+            if (!prNumberFile) {
+              core.setFailed('pr_number file not found in artifact');
+              return;
+            }
+            const prNumber = parseInt(fs.readFileSync(prNumberFile, 'utf8').trim(), 10);
+            if (isNaN(prNumber)) {
+              core.setFailed('Invalid PR number in artifact');
+              return;
+            }
+
+            // Read report (find the tmp file — it has a random name)
+            const files = fs.readdirSync(reportDir).filter(f => f !== 'pr_number');
+            let body = '## 🔒 Skill Security Audit\n\nNo report generated.';
+            if (files.length > 0) {
+              body = fs.readFileSync(path.join(reportDir, files[0]), 'utf8');
+            }
+
+            // Find and update existing comment or create new
+            const marker = '## 🔒 Skill Security Audit';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body,
+              });
+            }

--- a/.github/workflows/skill-security-audit.yml
+++ b/.github/workflows/skill-security-audit.yml
@@ -2,7 +2,7 @@
 name: Skill Security Audit
 
 'on':
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/**'
@@ -35,8 +35,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || '' }}
-
       - name: Find skills to audit
         id: list
         env:
@@ -48,7 +46,7 @@ jobs:
             SKILL_FILES=$(find . -name SKILL.md -not -path './.git/*' | sort)
             LABEL="All skills"
           else
-            if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            if [ "$EVENT_NAME" = "pull_request" ]; then
               CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD 2>/dev/null || echo "")
             else
               BEFORE="$PUSH_BEFORE"
@@ -101,12 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -190,53 +185,19 @@ jobs:
           echo "report_file=$REPORT_FILE" >> "$GITHUB_OUTPUT"
           echo "exit_code=$OVERALL_EXIT" >> "$GITHUB_OUTPUT"
 
-      - name: Post audit results as PR comment
-        if: always() && github.event_name == 'pull_request_target'
-        continue-on-error: true
-        uses: actions/github-script@v8
+      - name: Save PR number
+        if: always() && github.event_name == 'pull_request'
+        run: echo "${{ github.event.number }}" > "${{ runner.temp }}/pr_number"
+
+      - name: Upload audit report
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fs = require('fs');
-            const reportFile = '${{ steps.audit.outputs.report_file }}';
-            let body = '## 🔒 Skill Security Audit\n\nNo report generated.';
-            try {
-              body = fs.readFileSync(reportFile, 'utf8');
-            } catch (e) {
-              console.log('Could not read report file:', e.message);
-            }
-
-            try {
-              // Find and update existing comment or create new
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-              });
-              const marker = '## 🔒 Skill Security Audit';
-              const existing = comments.find(c => c.body.startsWith(marker));
-
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body: body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: body,
-                });
-              }
-            } catch (error) {
-              console.log('Could not post comment (expected for fork PRs):', error.message);
-              // Save report to GITHUB_STEP_SUMMARY as fallback
-              core.summary.addHeading('Skill Security Audit', 2);
-              core.summary.addRaw(body);
-              await core.summary.write();
-            }
+          name: security-audit-report
+          path: |
+            ${{ steps.audit.outputs.report_file }}
+            ${{ runner.temp }}/pr_number
+          retention-days: 5
 
       - name: Fail on critical findings
         if: steps.audit.outputs.exit_code == '1'


### PR DESCRIPTION
## Summary

- Fixes CodeQL alert [#1](https://github.com/ljagiello/ctf-skills/security/code-scanning/1) — **Checkout of untrusted code in trusted context** (CWE-829, high severity)
- Replaces `pull_request_target` trigger with unprivileged `pull_request` in `skill-security-audit.yml`, removing the explicit checkout of `github.event.pull_request.head.sha`
- Adds a new `skill-security-audit-comment.yml` workflow using `workflow_run` to post PR comments with write access, without ever checking out untrusted code

## Test plan

- [ ] Open a test PR that modifies a skill file and verify the "Skill Security Audit" workflow runs successfully under the `pull_request` trigger
- [ ] Verify the `workflow_run`-triggered comment workflow posts the audit report as a PR comment after the audit completes
- [ ] Confirm `push` to `main` and `workflow_dispatch` paths still work (no behavioral change for those triggers)
- [ ] Verify CodeQL alert #1 is resolved after merge