### PR TITLE
fix: scan bundled scripts in skill security auditor (#70)

### DIFF
--- a/scripts/skill_security_auditor.py
+++ b/scripts/skill_security_auditor.py
@@ -139,8 +139,13 @@ def has_shell_true_subprocess_call(line: str) -> bool:
     return match is not None
 
 
-def read_markdown_file(filepath: Path) -> tuple[str | None, dict | None]:
-    """Read a markdown file with strict UTF-8 handling."""
+# File extensions scanned in addition to Markdown. Scripts are treated as
+# entirely executable code (no fence tracking).
+SCRIPT_EXTENSIONS = (".py", ".sh", ".bash", ".js", ".ts", ".rb", ".pl")
+
+
+def read_text_file(filepath: Path) -> tuple[str | None, dict | None]:
+    """Read a text file with strict UTF-8 handling."""
     try:
         return filepath.read_text(encoding="utf-8"), None
     except UnicodeDecodeError as e:
@@ -176,20 +181,23 @@ def is_placeholder_xss_example(line: str) -> bool:
 def scan_file(filepath: Path) -> list:
     """Scan a single file and return findings."""
     findings = []
-    content, read_error = read_markdown_file(filepath)
+    content, read_error = read_text_file(filepath)
     if read_error is not None:
         findings.append(read_error)
         return findings
 
+    is_markdown = filepath.suffix.lower() == ".md"
     lines = content.splitlines()
 
-    # Check code blocks only (between ``` markers) for dangerous patterns
-    in_code_block = False
+    # For Markdown: track ``` fences. For scripts: the whole file is executable.
+    in_code_block = not is_markdown
     for i, line in enumerate(lines, 1):
         stripped = line.strip()
-        is_indented_code = line.startswith("    ") or line.startswith("\t")
+        is_indented_code = is_markdown and (
+            line.startswith("    ") or line.startswith("\t")
+        )
 
-        if stripped.startswith("```"):
+        if is_markdown and stripped.startswith("```"):
             in_code_block = not in_code_block
             continue
 
@@ -388,10 +396,13 @@ def scan_skill(skill_dir: Path) -> dict:
                         }
                     )
 
-    # Scan all markdown files
-    md_files = sorted(skill_dir.rglob("*.md"))
-    for md_file in md_files:
-        findings.extend(scan_file(md_file))
+    # Scan Markdown plus bundled scripts. Script assets are where real
+    # secrets/dangerous calls tend to hide; Markdown-only scanning misses them.
+    scan_targets: set[Path] = set(skill_dir.rglob("*.md"))
+    for ext in SCRIPT_EXTENSIONS:
+        scan_targets.update(skill_dir.rglob(f"*{ext}"))
+    for target in sorted(scan_targets):
+        findings.extend(scan_file(target))
 
     # Determine verdict
     crit = sum(1 for f in findings if f["severity"] == "CRITICAL")

--- a/tests/test_skill_security_auditor.py
+++ b/tests/test_skill_security_auditor.py
@@ -3,7 +3,7 @@ import textwrap
 import unittest
 from pathlib import Path
 
-from scripts.skill_security_auditor import scan_skill
+from scripts.skill_security_auditor import SCRIPT_EXTENSIONS, scan_skill
 
 
 class SkillSecurityAuditorTests(unittest.TestCase):
@@ -1015,6 +1015,256 @@ class SkillSecurityAuditorTests(unittest.TestCase):
 
         self.assertFalse(
             any(finding["severity"] == "HIGH" for finding in result["findings"])
+        )
+
+
+    def test_script_file_with_rm_rf_is_flagged_critical(self):
+        """Dangerous commands in bundled scripts (not just markdown) must be caught."""
+        skill_dir = self._make_skill(
+            textwrap.dedent(
+                """\
+                ---
+                name: demo-skill
+                description: Provides demo
+                license: MIT
+                allowed-tools: []
+                ---
+                """
+            ),
+            {
+                "scripts/demo.sh": "#!/bin/bash\nrm -rf /\n",
+            },
+        )
+
+        result = scan_skill(skill_dir)
+
+        self.assertEqual(result["verdict"], "FAIL")
+        self.assertTrue(
+            any(
+                finding["severity"] == "CRITICAL"
+                and "rm -rf /" in finding["message"]
+                and finding["file"].endswith("demo.sh")
+                for finding in result["findings"]
+            )
+        )
+
+    def test_script_file_with_os_system_fstring_is_flagged_high(self):
+        """HIGH patterns must fire on executable Python assets."""
+        skill_dir = self._make_skill(
+            textwrap.dedent(
+                """\
+                ---
+                name: demo-skill
+                description: Provides demo
+                license: MIT
+                allowed-tools: []
+                ---
+                """
+            ),
+            {
+                "scripts/demo.py": 'import os\nos.system(f"echo {user}")\n',
+            },
+        )
+
+        result = scan_skill(skill_dir)
+
+        self.assertTrue(
+            any(
+                finding["severity"] == "HIGH"
+                and "os.system()" in finding["message"]
+                and finding["file"].endswith("demo.py")
+                for finding in result["findings"]
+            )
+        )
+
+    def test_script_file_with_aws_key_is_flagged_critical(self):
+        """Hardcoded secrets in scripts must still trigger CRITICAL findings."""
+        skill_dir = self._make_skill(
+            textwrap.dedent(
+                """\
+                ---
+                name: demo-skill
+                description: Provides demo
+                license: MIT
+                allowed-tools: []
+                ---
+                """
+            ),
+            {
+                "scripts/creds.py": 'AWS_KEY = "AKIAIOSFODNN7EXAMPLE"\n',
+            },
+        )
+
+        result = scan_skill(skill_dir)
+
+        self.assertEqual(result["verdict"], "FAIL")
+        self.assertTrue(
+            any(
+                "AWS access key" in finding["message"]
+                and finding["file"].endswith("creds.py")
+                for finding in result["findings"]
+            )
+        )
+
+    def test_script_comment_not_flagged_for_high_pattern(self):
+        """Comment lines inside scripts are documentation, just like in fenced blocks."""
+        skill_dir = self._make_skill(
+            textwrap.dedent(
+                """\
+                ---
+                name: demo-skill
+                description: Provides demo
+                license: MIT
+                allowed-tools: []
+                ---
+                """
+            ),
+            {
+                "scripts/demo.py": '# os.system(f"unsafe {x}") would be bad\nprint("safe")\n',
+            },
+        )
+
+        result = scan_skill(skill_dir)
+
+        self.assertFalse(
+            any(
+                finding["severity"] == "HIGH"
+                and "os.system()" in finding["message"]
+                for finding in result["findings"]
+            )
+        )
+
+    def test_script_ctf_exec_allowlist_still_applies(self):
+        """CTF allowlists (exec('id')) carry over to script-file scanning."""
+        skill_dir = self._make_skill(
+            textwrap.dedent(
+                """\
+                ---
+                name: demo-skill
+                description: Provides demo
+                license: MIT
+                allowed-tools: []
+                ---
+                """
+            ),
+            {
+                "scripts/poc.py": 'exec("id")\n',
+            },
+        )
+
+        result = scan_skill(skill_dir)
+
+        self.assertFalse(
+            any(
+                finding["severity"] == "HIGH"
+                and "exec()" in finding["message"]
+                for finding in result["findings"]
+            )
+        )
+
+
+    def test_every_script_extension_is_scanned(self):
+        """Every extension in SCRIPT_EXTENSIONS actually gets scanned."""
+        for ext in SCRIPT_EXTENSIONS:
+            with self.subTest(ext=ext):
+                skill_dir = self._make_skill(
+                    textwrap.dedent(
+                        """\
+                        ---
+                        name: demo-skill
+                        description: Provides demo
+                        license: MIT
+                        allowed-tools: []
+                        ---
+                        """
+                    ),
+                    {
+                        f"scripts/payload{ext}": (
+                            'AWS_KEY = "AKIAIOSFODNN7EXAMPLE"\n'
+                        ),
+                    },
+                )
+
+                result = scan_skill(skill_dir)
+
+                self.assertTrue(
+                    any(
+                        finding["severity"] == "CRITICAL"
+                        and "AWS access key" in finding["message"]
+                        and finding["file"].endswith(f"payload{ext}")
+                        for finding in result["findings"]
+                    ),
+                    f"{ext} files not being scanned",
+                )
+
+    def test_script_with_backticks_is_not_misinterpreted_as_code_fence(self):
+        """Triple-backtick strings in a script must not toggle fence tracking off."""
+        skill_dir = self._make_skill(
+            textwrap.dedent(
+                """\
+                ---
+                name: demo-skill
+                description: Provides demo
+                license: MIT
+                allowed-tools: []
+                ---
+                """
+            ),
+            {
+                "scripts/demo.py": textwrap.dedent(
+                    '''\
+                    USAGE = """
+                    ```
+                    run me
+                    ```
+                    """
+                    rm_cmd = "rm -rf /"
+                    '''
+                ),
+            },
+        )
+
+        result = scan_skill(skill_dir)
+
+        self.assertTrue(
+            any(
+                finding["severity"] == "CRITICAL"
+                and "rm -rf /" in finding["message"]
+                for finding in result["findings"]
+            )
+        )
+
+    def test_invalid_utf8_script_produces_high_finding(self):
+        """Invalid UTF-8 in a script should produce the same unreadable_file finding."""
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        skill_dir = Path(temp_dir.name) / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            textwrap.dedent(
+                """\
+                ---
+                name: demo-skill
+                description: Provides demo
+                license: MIT
+                allowed-tools: []
+                ---
+                """
+            ),
+            encoding="utf-8",
+        )
+        (skill_dir / "scripts").mkdir()
+        (skill_dir / "scripts" / "broken.py").write_bytes(b"\xff\xfe\x00")
+
+        result = scan_skill(skill_dir)
+
+        self.assertTrue(
+            any(
+                finding["severity"] == "HIGH"
+                and finding["rule"] == "unreadable_file"
+                and finding["file"].endswith("broken.py")
+                for finding in result["findings"]
+            )
         )
 
 


### PR DESCRIPTION
## Summary
- `skill_security_auditor.py` only globbed `*.md`, so risky patterns in `scripts/` (`.py`, `.sh`, etc.) were invisible to the auditor — a planted AWS key or `os.system(f"…")` in a bundled Python helper returned a clean `PASS`.
- `scan_file()` now treats non-Markdown files as entirely executable (no ```` ``` ```` fence tracking, no Markdown indent heuristic). Existing comment-prefix skipping and CTF allowlists (`$eval` / `exec('id')` / `chmod 777 /tmp/`) carry over unchanged.
- `scan_skill()` globs `*.md` plus `SCRIPT_EXTENSIONS = (.py, .sh, .bash, .js, .ts, .rb, .pl)`.

Fixes #70.

## Test plan
- [x] `pytest tests/` — 57 passed, 1616 subtests (was 54 passed, 1609 subtests).
- [x] `ruff check scripts/` + `ruff format --check scripts/` clean (matches `lint-scripts.yml` CI).
- [x] End-to-end CLI repro of the exact scenario from #70: planted `ctf-demo/scripts/demo.py` with an AWS key and `os.system(f"…")`. On `main` → `PASS` (reproduces bug); on this branch → `FAIL` with 1 CRITICAL + 1 HIGH at the correct lines.
- [x] Ran auditor against all 11 shipped skills — no new findings; the one pre-existing `ctf-web` WARN is unchanged.
- [x] New tests cover: CRITICAL/HIGH/SECRET patterns in scripts, comment-line suppression in scripts, CTF allowlist carryover, every extension in `SCRIPT_EXTENSIONS` (parameterised), triple-backtick strings inside a script (must not toggle fence state), and invalid-UTF-8 scripts.