### PR TITLE
docs: add Friday Studio section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@
 npx skills add ljagiello/ctf-skills
 ```
 
+## Run with Friday Studio
+
+Want these skills as part of a real workflow — schedules, signals, MCP tools, memory, the works? Drop them into [Friday](https://hellofriday.ai/), the shareable AI workspace runtime from [Tempest Labs](https://hellofriday.ai/).
+
+Friday Studio loads skills into agent context on demand and runs them inside reproducible workspaces that you can trigger from chat, on a cron, or over HTTP. Everything runs locally, your data stays on your machine, and every step is logged so you can see exactly what the agent did during a challenge.
+
+To add these skills to Friday Studio:
+
+1. Install Friday from [hellofriday.ai](https://hellofriday.ai/) (macOS).
+2. Open **Skills** in the Studio sidebar and click **+ Add**.
+3. Import individual skills by reference (e.g. `ljagiello/ctf-skills/ctf-web`), or upload this repo as a folder.
+4. Reference them from any `workspace.yml`, or let agents load them automatically based on the skill description.
+
+See the [Friday Skills docs](https://docs.hellofriday.ai/core-concepts/skills) for the full workflow, and the [Friday blog](https://blog.hellofriday.ai/) — including [AI Drift: The Hidden Cost of Building with AI](https://blog.hellofriday.ai/ai-drift-the-hidden-cost-of-building-with-ai-e2b51415b3b0) — for the philosophy behind it.
+
 ## Environment Setup
 
 Two setup strategies depending on your workflow:


### PR DESCRIPTION
## Summary

- Add a "Run with Friday Studio" section to README.md, positioning [Friday](https://hellofriday.ai/) as a workspace runtime for these CTF skills (schedules, signals, MCP tools, local execution, transparent logging).
- Walk through the Studio sidebar add flow, leading with the `owner/repo/slug` import-by-reference path (`ljagiello/ctf-skills/<skill>`), with folder upload as the fallback.
- Link the [Friday Skills docs](https://docs.hellofriday.ai/core-concepts/skills) and the [AI Drift](https://blog.hellofriday.ai/ai-drift-the-hidden-cost-of-building-with-ai-e2b51415b3b0) blog post.

Verified the import-by-reference format against `friday-platform/friday-studio` source: Studio's import field accepts `owner/repo/slug` (placeholder `anthropics/skills/pdf`), parsed at `apps/atlasd/routes/skills.ts:151-179`, resolved via `https://skills.sh/api/download/{owner}/{repo}/{slug}`.

## Test plan

- [ ] Render README on GitHub and confirm links resolve (hellofriday.ai, docs.hellofriday.ai/core-concepts/skills, blog AI Drift post).
- [ ] In Friday Studio, paste `ljagiello/ctf-skills/ctf-web` into the **+ Add → Import skill** field and confirm it installs.
- [ ] Confirm the section placement (between Installation and Environment Setup) reads naturally and doesn't bury the existing `npx skills add` path.