### PR TITLE
docs: add Autohand Code install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@
 npx skills add ljagiello/ctf-skills
 ```
 
+### Autohand Code
+
+Autohand Code loads `SKILL.md` directories from `~/.autohand/skills/` or the current project's `.autohand/skills/` directory.
+
+Install all CTF skills globally:
+
+```bash
+git clone https://github.com/ljagiello/ctf-skills.git
+mkdir -p ~/.autohand/skills
+cp -R ctf-skills/ctf-* ctf-skills/solve-challenge ~/.autohand/skills/
+```
+
+Install only the skills needed for a project:
+
+```bash
+git clone https://github.com/ljagiello/ctf-skills.git
+mkdir -p .autohand/skills
+cp -R ctf-skills/ctf-web ctf-skills/solve-challenge .autohand/skills/
+```
+
+If a skill is later published to an Autohand Skills index, install it with `autohand --skill-install <skill-name>`, or add `--project` to install it into the current project.
+
 ## Run with Friday Studio
 
 Want these skills as part of a real workflow — schedules, signals, MCP tools, memory, the works? Drop them into [Friday](https://hellofriday.ai/), the shareable AI workspace runtime from [Tempest Labs](https://hellofriday.ai/).


### PR DESCRIPTION
## Summary

Adds Autohand Code install notes to the README so users can copy these `SKILL.md` directories into Autohand's global or project-local skill directories.

## Category

- Documentation / installation

## Source

- Not applicable; this does not add CTF techniques.

## Checklist

- [x] `pytest` tests pass (`python -m pytest tests/ -v`)
- [ ] Security audit is clean (`python3 scripts/skill_security_auditor.py <skill-dir> --strict`) <!-- no skill directory changed -->
- [x] Markdown lint is clean (`markdownlint-cli2`)
- [ ] Pre-commit hooks ran successfully (`pre-commit run --all-files`) <!-- not run locally -->
- [x] No leaked credentials, real IPs, or non-example domains in content

Validation run:
- `git diff --check`
- `/Users/igorcosta/Documents/autohand/everywhere/.venvs/ctf-skills/bin/python -m pytest tests/ -v`
- `npx -y markdownlint-cli2 README.md`

I did not run the security auditor because this PR only changes the root README install instructions and does not modify any skill directory.